### PR TITLE
+ highlightBuilder && - default padding on code block

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -401,6 +401,20 @@ Markdown and LaTeX can be powerful tools for formatting text and mathematical ex
                                         );
                                       },
                                     );
+                                    codeBuilder: (context, name, code) {
+                                      return Padding(
+                                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                                        child: Text(
+                                          code.trim(),
+                                          style: TextStyle(
+                                            fontFamily: 'JetBrains Mono',
+                                            fontSize: 14,
+                                            height: 1.5,
+                                            color: Theme.of(context).colorScheme.onSurface,
+                                          ),
+                                        ),
+                                      );
+                                    };
                                     if (selectable) {
                                       child = SelectionArea(
                                         child: child,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -99,6 +99,7 @@ class MarkdownHelper {
 
 You can use Markdown to format text easily. Here are some examples:
 
+- `Highlighted Text`: `This text is highlighted`
 - **Bold Text**: **This text is bold**
 - *Italic Text*: *This text is italicized*
 - [Link](https://www.example.com): [This is a link](https://www.example.com)
@@ -266,6 +267,29 @@ Markdown and LaTeX can be powerful tools for formatting text and mathematical ex
                                       style: const TextStyle(
                                         fontSize: 15,
                                       ),
+                                      highlightBuilder: (context, text, style) {
+                                        return Container(
+                                          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+                                          decoration: BoxDecoration(
+                                            color: Theme.of(context).colorScheme.secondaryContainer,
+                                            borderRadius: BorderRadius.circular(4),
+                                            border: Border.all(
+                                              color: Theme.of(context).colorScheme.secondary.withOpacity(0.5),
+                                              width: 1,
+                                            ),
+                                          ),
+                                          child: Text(
+                                            text,
+                                            style: TextStyle(
+                                              color: Theme.of(context).colorScheme.onSecondaryContainer,
+                                              fontFamily: 'monospace',
+                                              fontWeight: FontWeight.bold,
+                                              fontSize: style.fontSize != null ? style.fontSize! * 0.9 : 13.5,
+                                              height: style.height,
+                                            ),
+                                          ),
+                                        );
+                                      },
                                       latexWorkaround: (tex) {
                                         List<String> stack = [];
                                         tex = tex.splitMapJoin(

--- a/lib/custom_widgets/markdow_config.dart
+++ b/lib/custom_widgets/markdow_config.dart
@@ -13,6 +13,7 @@ class GptMarkdownConfig {
     this.codeBuilder,
     this.sourceTagBuilder,
     this.highlightBuilder,
+    this.linkBuilder,
     this.maxLines,
     this.overflow,
   });
@@ -34,6 +35,7 @@ class GptMarkdownConfig {
   final int? maxLines;
   final TextOverflow? overflow;
   final Widget Function(BuildContext context, String text, TextStyle style)? highlightBuilder;
+  final Widget Function(BuildContext context, String text, String url, TextStyle style)? linkBuilder;
 
   GptMarkdownConfig copyWith({
     TextStyle? style,
@@ -54,6 +56,7 @@ class GptMarkdownConfig {
     final int? maxLines,
     final TextOverflow? overflow,
     final Widget Function(BuildContext context, String text, TextStyle style)? highlightBuilder,
+    final Widget Function(BuildContext context, String text, String url, TextStyle style)? linkBuilder,
   }) {
     return GptMarkdownConfig(
       style: style ?? this.style,
@@ -69,6 +72,7 @@ class GptMarkdownConfig {
       maxLines: maxLines ?? this.maxLines,
       overflow: overflow ?? this.overflow,
       highlightBuilder: highlightBuilder ?? this.highlightBuilder,
+      linkBuilder: linkBuilder ?? this.linkBuilder,
     );
   }
 

--- a/lib/custom_widgets/markdow_config.dart
+++ b/lib/custom_widgets/markdow_config.dart
@@ -12,6 +12,7 @@ class GptMarkdownConfig {
     this.followLinkColor = false,
     this.codeBuilder,
     this.sourceTagBuilder,
+    this.highlightBuilder,
     this.maxLines,
     this.overflow,
   });
@@ -32,6 +33,7 @@ class GptMarkdownConfig {
       codeBuilder;
   final int? maxLines;
   final TextOverflow? overflow;
+  final Widget Function(BuildContext context, String text, TextStyle style)? highlightBuilder;
 
   GptMarkdownConfig copyWith({
     TextStyle? style,
@@ -51,6 +53,7 @@ class GptMarkdownConfig {
         codeBuilder,
     final int? maxLines,
     final TextOverflow? overflow,
+    final Widget Function(BuildContext context, String text, TextStyle style)? highlightBuilder,
   }) {
     return GptMarkdownConfig(
       style: style ?? this.style,
@@ -65,6 +68,7 @@ class GptMarkdownConfig {
       sourceTagBuilder: sourceTagBuilder ?? this.sourceTagBuilder,
       maxLines: maxLines ?? this.maxLines,
       overflow: overflow ?? this.overflow,
+      highlightBuilder: highlightBuilder ?? this.highlightBuilder,
     );
   }
 

--- a/lib/gpt_markdown.dart
+++ b/lib/gpt_markdown.dart
@@ -35,6 +35,7 @@ class GptMarkdown extends StatelessWidget {
     this.codeBuilder,
     this.sourceTagBuilder,
     this.highlightBuilder,
+    this.linkBuilder,
     this.maxLines,
     this.overflow,
   });
@@ -55,6 +56,7 @@ class GptMarkdown extends StatelessWidget {
       codeBuilder;
   final Widget Function(BuildContext, String, TextStyle)? sourceTagBuilder;
   final Widget Function(BuildContext context, String text, TextStyle style)? highlightBuilder;
+  final Widget Function(BuildContext context, String text, String url, TextStyle style)? linkBuilder;
 
   @override
   Widget build(BuildContext context) {
@@ -96,6 +98,7 @@ class GptMarkdown extends StatelessWidget {
         overflow: overflow,
         sourceTagBuilder: sourceTagBuilder,
         highlightBuilder: highlightBuilder,
+        linkBuilder: linkBuilder,
       ),
     ));
   }

--- a/lib/gpt_markdown.dart
+++ b/lib/gpt_markdown.dart
@@ -34,6 +34,7 @@ class GptMarkdown extends StatelessWidget {
     this.latexBuilder,
     this.codeBuilder,
     this.sourceTagBuilder,
+    this.highlightBuilder,
     this.maxLines,
     this.overflow,
   });
@@ -53,6 +54,7 @@ class GptMarkdown extends StatelessWidget {
   final Widget Function(BuildContext context, String name, String code)?
       codeBuilder;
   final Widget Function(BuildContext, String, TextStyle)? sourceTagBuilder;
+  final Widget Function(BuildContext context, String text, TextStyle style)? highlightBuilder;
 
   @override
   Widget build(BuildContext context) {
@@ -93,6 +95,7 @@ class GptMarkdown extends StatelessWidget {
         maxLines: maxLines,
         overflow: overflow,
         sourceTagBuilder: sourceTagBuilder,
+        highlightBuilder: highlightBuilder,
       ),
     ));
   }

--- a/lib/markdown_component.dart
+++ b/lib/markdown_component.dart
@@ -422,25 +422,37 @@ class HighlightedText extends InlineMd {
     final GptMarkdownConfig config,
   ) {
     var match = exp.firstMatch(text.trim());
-    var conf = config.copyWith(
-      style: config.style?.copyWith(
-            fontWeight: FontWeight.bold,
-            background: Paint()
-              ..color = GptMarkdownTheme.of(context).highlightColor
-              ..strokeCap = StrokeCap.round
-              ..strokeJoin = StrokeJoin.round,
-          ) ??
-          TextStyle(
-            fontWeight: FontWeight.bold,
-            background: Paint()
-              ..color = GptMarkdownTheme.of(context).highlightColor
-              ..strokeCap = StrokeCap.round
-              ..strokeJoin = StrokeJoin.round,
-          ),
-    );
+    var highlightedText = match?[1] ?? "";
+
+    if (config.highlightBuilder != null) {
+      return WidgetSpan(
+        alignment: PlaceholderAlignment.middle,
+        child: config.highlightBuilder!(
+          context,
+          highlightedText,
+          config.style ?? const TextStyle(),
+        ),
+      );
+    }
+
+    var style = config.style?.copyWith(
+          fontWeight: FontWeight.bold,
+          background: Paint()
+            ..color = GptMarkdownTheme.of(context).highlightColor
+            ..strokeCap = StrokeCap.round
+            ..strokeJoin = StrokeJoin.round,
+        ) ??
+        TextStyle(
+          fontWeight: FontWeight.bold,
+          background: Paint()
+            ..color = GptMarkdownTheme.of(context).highlightColor
+            ..strokeCap = StrokeCap.round
+            ..strokeJoin = StrokeJoin.round,
+        );
+
     return TextSpan(
-      text: match?[1],
-      style: conf.style,
+      text: highlightedText,
+      style: style,
     );
   }
 }
@@ -892,11 +904,9 @@ class CodeBlockMd extends BlockMd {
     String codes = this.exp.firstMatch(text)?[2] ?? "";
     String name = this.exp.firstMatch(text)?[1] ?? "";
     codes = codes.replaceAll(r"```", "").trim();
-    return Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: config.codeBuilder != null
-          ? config.codeBuilder?.call(context, name, codes)
-          : CodeField(name: name, codes: codes),
-    );
+    
+    return config.codeBuilder != null
+        ? config.codeBuilder!(context, name, codes)
+        : CodeField(name: name, codes: codes);
   }
 }

--- a/lib/markdown_component.dart
+++ b/lib/markdown_component.dart
@@ -733,15 +733,35 @@ class ATagMd extends InlineMd {
     if (match?[1] == null && match?[2] == null) {
       return const TextSpan();
     }
+    
+    final linkText = match?[1] ?? "";
+    final url = match?[2] ?? "";
+    
+    // Use custom builder if provided
+    if (config.linkBuilder != null) {
+      return WidgetSpan(
+        child: GestureDetector(
+          onTap: () => config.onLinkTab?.call(url, linkText),
+          child: config.linkBuilder!(
+            context,
+            linkText,
+            url,
+            config.style ?? const TextStyle(),
+          ),
+        ),
+      );
+    }
+
+    // Default rendering
     var theme = GptMarkdownTheme.of(context);
     return WidgetSpan(
       child: LinkButton(
         hoverColor: theme.linkHoverColor,
         color: theme.linkColor,
         onPressed: () {
-          config.onLinkTab?.call("${match?[2]}", "${match?[1]}");
+          config.onLinkTab?.call(url, linkText);
         },
-        text: match?[1] ?? "",
+        text: linkText,
         config: config,
       ),
     );


### PR DESCRIPTION
Hi there!

Awesome package! Will contribute more for sure - just added an highlight builder: basically the same thing than the codeBuilder for highlighted text `like this`. This allows stuff like:

![image](https://github.com/user-attachments/assets/e43310df-d57c-4f33-9944-f0849bedb15c)

Also I removed the default padding on the code block as it renders horribly on message bubbles with transparent background (justified text is misaligned with the code block) - users can just add as much padding as they want in their custom codeBuilder.

Edit: Added linkBuilder as well