### PR TITLE
fix: multiple links next to each other are resolved as single link

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,6 +20,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   ThemeMode _themeMode = ThemeMode.dark;
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -64,6 +65,7 @@ class _MyAppState extends State<MyApp> {
 
 class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key, required this.title, required this.onPressed});
+
   final VoidCallback? onPressed;
 
   final String title;
@@ -181,8 +183,7 @@ Markdown and LaTeX can be powerful tools for formatting text and mathematical ex
                     ? Theme.of(context).colorScheme.onSurfaceVariant
                     : Theme.of(context)
                         .colorScheme
-                        .onSurface
-                        .withValues(alpha: 0.38),
+                        .onSurface /* .withValues(alpha: 0.38) */,
               ),
             ),
             IconButton(
@@ -280,8 +281,7 @@ Markdown and LaTeX can be powerful tools for formatting text and mathematical ex
                                             border: Border.all(
                                               color: Theme.of(context)
                                                   .colorScheme
-                                                  .secondary
-                                                  .withValues(alpha: 0.5),
+                                                  .secondary /* .withValues(alpha: 0.5) */,
                                               width: 1,
                                             ),
                                           ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   cross_file:
     dependency: transitive
     description:
@@ -126,7 +126,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.6"
+    version: "1.0.8"
   http:
     dependency: transitive
     description:
@@ -139,26 +139,26 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "76d306a1c3afb33fe82e2bbacad62a61f409b5634c915fceb0d799de1a913360"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.0.2"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -243,7 +243,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.0.99"
   source_span:
     dependency: transitive
     description:
@@ -256,10 +256,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
@@ -272,10 +272,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -288,10 +288,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.2"
   tuple:
     dependency: transitive
     description:
@@ -344,10 +344,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.2.5"
   watcher:
     dependency: "direct main"
     description:

--- a/lib/markdown_component.dart
+++ b/lib/markdown_component.dart
@@ -348,7 +348,7 @@ class IndentMd extends InlineMd {
                 direction: config.textDirection,
                 child: Padding(
                   padding: const EdgeInsetsDirectional.only(start: 10.0),
-                  child: Expanded(child: config.getRich(child)),
+                  child: config.getRich(child),
                 ),
               ),
             ),

--- a/lib/markdown_component.dart
+++ b/lib/markdown_component.dart
@@ -16,7 +16,6 @@ abstract class MarkdownComponent {
         HrLine(),
         LatexMath(),
         LatexMathMultiLine(),
-        ImageMd(),
         HighlightedText(),
         StrikeMd(),
         BoldMd(),
@@ -779,7 +778,7 @@ class ATagMd extends InlineMd {
 /// Image component
 class ImageMd extends InlineMd {
   @override
-  RegExp get exp => RegExp(r"\!\[([^\s][^\n]*[^\s]?)?\]\(([^\s]+?)\)");
+  RegExp get exp => RegExp(r"!\[([^\]]*)\]\((?<url>[^)]+)\)");
 
   @override
   InlineSpan span(
@@ -788,40 +787,40 @@ class ImageMd extends InlineMd {
     final GptMarkdownConfig config,
   ) {
     var match = exp.firstMatch(text.trim());
-    double? height;
-    double? width;
-    if (match?[1] != null) {
-      var size = RegExp(r"^([0-9]+)?x?([0-9]+)?")
-          .firstMatch(match![1].toString().trim());
-      width = double.tryParse(size?[1]?.toString().trim() ?? 'a');
-      height = double.tryParse(size?[2]?.toString().trim() ?? 'a');
+    final url = match?.namedGroup('url');
+    if (url == null || url.isEmpty) {
+      return const TextSpan();
     }
+
+    // double? height;
+    // double? width;
+    // if (match?[1] != null) {
+    //   var size = RegExp(r"^([0-9]+)?x?([0-9]+)?")
+    //       .firstMatch(match![1].toString().trim());
+    //   width = double.tryParse(size?[1]?.toString().trim() ?? 'a');
+    //   height = double.tryParse(size?[2]?.toString().trim() ?? 'a');
+    // }
+
     return WidgetSpan(
       alignment: PlaceholderAlignment.bottom,
-      child: SizedBox(
-        width: width,
-        height: height,
-        child: Image(
-          image: NetworkImage(
-            "${match?[2]}",
-          ),
-          loadingBuilder: (BuildContext context, Widget child,
-              ImageChunkEvent? loadingProgress) {
-            if (loadingProgress == null) {
-              return child;
-            }
-            return CustomImageLoading(
-              progress: loadingProgress.expectedTotalBytes != null
-                  ? loadingProgress.cumulativeBytesLoaded /
-                      loadingProgress.expectedTotalBytes!
-                  : 1,
-            );
-          },
-          fit: BoxFit.fill,
-          errorBuilder: (context, error, stackTrace) {
-            return const CustomImageError();
-          },
-        ),
+      child: Image(
+        image: NetworkImage(url),
+        loadingBuilder: (BuildContext context, Widget child,
+            ImageChunkEvent? loadingProgress) {
+          if (loadingProgress == null) {
+            return child;
+          }
+          return CustomImageLoading(
+            progress: loadingProgress.expectedTotalBytes != null
+                ? loadingProgress.cumulativeBytesLoaded /
+                    loadingProgress.expectedTotalBytes!
+                : 1,
+          );
+        },
+        fit: BoxFit.fill,
+        errorBuilder: (context, error, stackTrace) {
+          return const CustomImageError();
+        },
       ),
     );
   }

--- a/lib/markdown_component.dart
+++ b/lib/markdown_component.dart
@@ -102,6 +102,7 @@ abstract class MarkdownComponent {
   );
 
   RegExp get exp;
+
   bool get inline;
 }
 
@@ -170,6 +171,7 @@ abstract class BlockMd extends MarkdownComponent {
 class HTag extends BlockMd {
   @override
   String get expString => (r"(?<hash>#{1,6})\ (?<data>[^\n]+?)$");
+
   @override
   Widget build(
     BuildContext context,
@@ -221,6 +223,7 @@ class HTag extends BlockMd {
 class NewLines extends InlineMd {
   @override
   RegExp get exp => RegExp(r"\n\n+");
+
   @override
   InlineSpan span(
     BuildContext context,
@@ -241,6 +244,7 @@ class NewLines extends InlineMd {
 class HrLine extends BlockMd {
   @override
   String get expString => (r"(--)[-]+$");
+
   @override
   Widget build(
     BuildContext context,
@@ -260,6 +264,7 @@ class HrLine extends BlockMd {
 class CheckBoxMd extends BlockMd {
   @override
   String get expString => (r"\[(\x?)\]\ (\S[^\n]*?)$");
+
   get onLinkTab => null;
 
   @override
@@ -284,6 +289,7 @@ class CheckBoxMd extends BlockMd {
 class RadioButtonMd extends BlockMd {
   @override
   String get expString => (r"\((\x?)\)\ (\S[^\n]*)$");
+
   get onLinkTab => null;
 
   @override
@@ -308,6 +314,7 @@ class RadioButtonMd extends BlockMd {
 class IndentMd extends InlineMd {
   @override
   bool get inline => false;
+
   @override
   RegExp get exp =>
       // RegExp(r"(?<=\n\n)(\ +)(.+?)(?=\n\n)", dotAll: true, multiLine: true);
@@ -542,6 +549,7 @@ class ItalicMd extends InlineMd {
 class LatexMathMultiLine extends BlockMd {
   @override
   String get expString => (r"\\\[(((?!\n\n).)*?)\\\]|(\\begin.*?\\end{.*?})");
+
   @override
   RegExp get exp => RegExp(expString, dotAll: true, multiLine: true);
 
@@ -720,7 +728,8 @@ class SourceTag extends InlineMd {
 /// Link text component
 class ATagMd extends InlineMd {
   @override
-  RegExp get exp => RegExp(r"\[([^\s\*\[][^\n]*?[^\s]?)?\]\(([^\s\*]*[^\)])\)");
+  RegExp get exp =>
+      RegExp(r"(?<!!)\[((?:[^\]\n]|\\\])*)\]\(((?:[^)\n]|\\\))*)\)");
 
   @override
   InlineSpan span(
@@ -823,6 +832,7 @@ class TableMd extends BlockMd {
   @override
   String get expString =>
       (r"(((\|[^\n\|]+\|)((([^\n\|]+\|)+)?))(\n(((\|[^\n\|]+\|)(([^\n\|]+\|)+)?)))+)$");
+
   @override
   Widget build(
     BuildContext context,
@@ -914,6 +924,7 @@ class TableMd extends BlockMd {
 class CodeBlockMd extends BlockMd {
   @override
   String get expString => r"```(.*?)\n((.*?)(:?\n\s*?```)|(.*)(:?\n```)?)$";
+
   @override
   Widget build(
     BuildContext context,


### PR DESCRIPTION
Trying to fix https://github.com/Infinitix-LLC/gpt_markdown/issues/34

---

The test case is as follows

```dart
final cases = [
  // (raw content, expected)
  ('![link](url)', 0),
  ('[link](url)', 1),
  ('[li\nnk](url)', 0),
  ('[link](u\nrl)', 0),
  ('[li\\]nk](url)', 1),
  ('[link](ur\\)l)', 1),
  ('[link](url)[link2](url2)', 2),
  ('[link](url) [link2](url2)', 2),
];

void main() {
  final reg = RegExp(
    r"(?<!!)\[((?:[^\]\n]|\\\])*)\]\(((?:[^)\n]|\\\))*)\)",
    dotAll: true,
    multiLine: true,
  );

  for (final entry in cases) {
    print(
        "${entry.$1.replaceAll('\n', '\\n')} => ${reg.allMatches(entry.$1).length}/${entry.$2}");
  }
}
```

![image](https://github.com/user-attachments/assets/3794fb48-7b55-463d-83be-60cf371e9765)
