### PR TITLE
Fix theme color not taken into account when a style is present

### DIFF
--- a/lib/markdown_component.dart
+++ b/lib/markdown_component.dart
@@ -855,8 +855,11 @@ class ATagMd extends InlineMd {
     );
     var theme = GptMarkdownTheme.of(context);
     var linkTextSpan = TextSpan(
-      children: MarkdownComponent.generate(context, linkText, config, false),
-      style: config.style?.copyWith(color: theme.linkColor),
+      text: linkText,
+      style: config.style?.copyWith(
+        color: theme.linkColor,
+        decorationColor: theme.linkColor,
+      ),
     );
 
     // Use custom builder if provided


### PR DESCRIPTION
# Motivation

Currently if a theme is set the link colors are not properly taken into account because we regenerate a `MarkdownComponent` from config, which is child of the `TextSpan` and override the `Textspan`'s style

Switching to a simple TextSpan seems enough but otherwise we need to do something like this

```dart
    var theme = GptMarkdownTheme.of(context);
    final style = config.style?.copyWith(
      color: theme.linkColor,
      decorationColor: theme.linkColor,
    );
    final newConfig = config.copyWith(style: style);
    var linkTextSpan = TextSpan(

      children: MarkdownComponent.generate(context, linkText, newConfig, false),
      style: style,
    );
```

Note i also set the decorationColor to the style, to follow the logic in `LinkButton`.



# Notes on link customization

I feel link layout customization is a bit edgy:

- if there is no `config.style` then the theme colors are completely ignored. Maybe we should detfault to `TexStyle()` (same logic as LinkButton) (or simply not pass the child to linkButton and let him handle it ?)
- If one want's another TextStyle for links like bold it's not possible without a custom builder, maybe an optional linksTextStyle in config is a good idea
- If there is a config.style, then link do not have underline (since we pass child to LinkButton)
- Maybe the linkDecoration and linkDecorationColors should also be in the Theme
- 