### PR TITLE
fix: ordered list numbers alignment and style override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.6
+
+* Fixed ordered list numbers vertical alignment issue by using dynamically calculated width with right-aligned text
+* Width is now calculated based on "99." using the current font style, ensuring proper alignment across different font sizes
+* Added optional `numberWidth` parameter to `OrderedListView` for manual width override if needed
+* Improved RTL support for ordered lists (numbers are left-aligned in RTL mode)
+* Fixed ordered list number style override issue - numbers now respect the configured text style ([#105](https://github.com/Infinitix-LLC/gpt_markdown/issues/105))
+
 ## 1.1.5
 
 * Fixed block latex markdown syntax.

--- a/lib/custom_widgets/unordered_ordered_list.dart
+++ b/lib/custom_widgets/unordered_ordered_list.dart
@@ -77,14 +77,28 @@ class UnorderedListView extends StatelessWidget {
 /// It takes a [child] parameter which is the content of the list item,
 /// a [spacing] parameter to set the spacing between items,
 /// a [padding] parameter to set the padding of the list item,
+/// and an optional [numberWidth] parameter to override the calculated width.
 class OrderedListView extends StatelessWidget {
+  /// The list item number (e.g., "1.", "2.", "10.").
   final String no;
+
+  /// The spacing between the number and content.
   final double spacing;
+
+  /// The padding before the number.
   final double padding;
+
+  /// Optional fixed width for the number container.
+  /// If null, width is calculated dynamically based on font size.
+  /// The calculated width accommodates "99." by default for proper alignment
+  /// in typical lists (up to 99 items).
+  final double? numberWidth;
+
   const OrderedListView({
     super.key,
     this.spacing = 6,
     this.padding = 6,
+    this.numberWidth,
     TextStyle? style,
     required this.child,
     this.textDirection = TextDirection.ltr,
@@ -100,8 +114,26 @@ class OrderedListView extends StatelessWidget {
   /// The child widget to be displayed in the list item.
   final Widget child;
 
+  /// Calculate the width needed for "99." to ensure consistent alignment.
+  double _calculateNumberWidth(BuildContext context) {
+    if (numberWidth != null) return numberWidth!;
+
+    // Use the current style or default text style
+    final effectiveStyle = _style ?? DefaultTextStyle.of(context).style;
+
+    // Calculate width for "99." which accommodates most lists
+    final textPainter = TextPainter(
+      text: TextSpan(text: '99.', style: effectiveStyle),
+      textDirection: textDirection,
+    )..layout();
+
+    return textPainter.width;
+  }
+
   @override
   Widget build(BuildContext context) {
+    final calculatedWidth = _calculateNumberWidth(context);
+
     return Directionality(
       textDirection: textDirection,
       child: Row(
@@ -109,10 +141,23 @@ class OrderedListView extends StatelessWidget {
         textBaseline: TextBaseline.alphabetic,
         crossAxisAlignment: CrossAxisAlignment.baseline,
         children: [
+          // Fixed-width container for right-aligned numbers
+          // This ensures proper vertical alignment regardless of digit count
           Padding(
-            padding: EdgeInsetsDirectional.only(start: padding, end: spacing),
-            child: Text.rich(TextSpan(text: no), style: _style),
+            padding: EdgeInsetsDirectional.only(start: padding),
+            child: SizedBox(
+              width: calculatedWidth,
+              child: Text(
+                no,
+                style: _style,
+                textAlign:
+                    textDirection == TextDirection.rtl
+                        ? TextAlign.left
+                        : TextAlign.right,
+              ),
+            ),
           ),
+          SizedBox(width: spacing),
           Flexible(child: child),
         ],
       ),

--- a/lib/markdown_component.dart
+++ b/lib/markdown_component.dart
@@ -442,9 +442,7 @@ class OrderedList extends BlockMd {
         OrderedListView(
           no: "$no.",
           textDirection: config.textDirection,
-          style: (config.style ?? const TextStyle()).copyWith(
-            fontWeight: FontWeight.w100,
-          ),
+          style: config.style,
           child: child,
         );
   }


### PR DESCRIPTION
## Summary
This PR fixes two related issues with ordered list rendering:
1. **Numbers not vertically aligned** - Numbers now use a dynamically calculated fixed width
2. **Style override issue (#105)** - Numbers now respect user-configured text styles
Fixes #105
## Changes
- [OrderedListView](cci:2://file:///home/kylesean/projects/dart/gpt_markdown/lib/custom_widgets/unordered_ordered_list.dart:80:0-165:1): Added dynamic width calculation using TextPainter
- [OrderedListView](cci:2://file:///home/kylesean/projects/dart/gpt_markdown/lib/custom_widgets/unordered_ordered_list.dart:80:0-165:1): Added optional `numberWidth` parameter for manual override
- [OrderedListView](cci:2://file:///home/kylesean/projects/dart/gpt_markdown/lib/custom_widgets/unordered_ordered_list.dart:80:0-165:1): Improved RTL support (left-align numbers in RTL mode)
- [OrderedList](cci:2://file:///home/kylesean/projects/dart/gpt_markdown/lib/markdown_component.dart:420:0-448:1): Removed forced `fontWeight: FontWeight.w100` override
## Testing
- `flutter analyze` passes
- `flutter test` passes