### PR TITLE
fix: links with title not parsed / LinkButton.url not populated

### DIFF
--- a/lib/markdown_component.dart
+++ b/lib/markdown_component.dart
@@ -782,7 +782,7 @@ class SourceTag extends InlineMd {
 /// Link text component
 class ATagMd extends InlineMd {
   @override
-  RegExp get exp => RegExp(r"(?<!\!)\[.*\]\([^\s]*\)");
+  RegExp get exp => RegExp(r'(?<!\!)\[.*\]\([^\s\)]*(?:\s+"[^"]*")?\)');
 
   @override
   InlineSpan span(
@@ -843,7 +843,10 @@ class ATagMd extends InlineMd {
       return const TextSpan();
     }
 
-    final url = text.substring(urlStart, urlEnd).trim();
+    var rawUrl = text.substring(urlStart, urlEnd).trim();
+    // Remove title if present: url "title" -> url
+    final titleMatch = RegExp(r'^(\S+)\s+"[^"]*"$').firstMatch(rawUrl);
+    final url = titleMatch != null ? titleMatch.group(1)! : rawUrl;
 
     var builder = config.linkBuilder;
 
@@ -893,6 +896,7 @@ class ATagMd extends InlineMd {
           config.onLinkTap?.call(url, linkText);
         },
         text: linkText,
+        url: url,
         config: config,
         child: config.getRich(linkTextSpan),
       ),

--- a/lib/markdown_component.dart
+++ b/lib/markdown_component.dart
@@ -861,7 +861,9 @@ class ATagMd extends InlineMd {
     var theme = GptMarkdownTheme.of(context);
     var linkTextSpan = TextSpan(
       children: MarkdownComponent.generate(context, linkText, config, false),
-      style: config.style?.copyWith(
+      // changed from config.style?.copyWith()
+      // so that default style is applied when config.style is null
+      style: config.style ?? TextStyle(
         color: theme.linkColor,
         decorationColor: theme.linkColor,
       ),

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,346 @@
+# GPT Markdown Test Framework
+
+This directory contains the widget test framework for the `gpt_markdown` package. The framework uses a custom serializer to produce stable, comparable string representations of the rendered markdown output.
+
+## Overview
+
+### Design Philosophy
+
+The test framework is designed around these principles:
+
+1. **Stable Output**: Tests compare serialized string representations rather than widget instances, avoiding issues with theme-dependent styles, memory addresses, and Flutter version changes.
+
+2. **Semantic Testing**: The serializer captures the semantic meaning (bold, italic, list items, etc.) rather than visual details (colors, font sizes).
+
+3. **Granular Organization**: Each markdown feature has its own test file for easy navigation and focused testing.
+
+4. **Bug Tracking**: A two-folder system separates known unfixed bugs (`/bugs`) from fixed bugs (`/regression`) to track issues and prevent recurrence.
+
+## Directory Structure
+
+```
+test/
+├── README.md                    # This file
+├── utils/
+│   ├── serializer.dart          # Custom stable serializer
+│   └── test_helpers.dart        # Shared test utilities
+│
+├── inline/                      # Inline element tests
+│   ├── bold_test.dart
+│   ├── italic_test.dart
+│   ├── strikethrough_test.dart
+│   ├── underline_test.dart
+│   ├── highlight_test.dart
+│   └── links_test.dart
+│
+├── block/                       # Block element tests
+│   ├── headings_test.dart
+│   ├── code_block_test.dart
+│   ├── unordered_list_test.dart
+│   ├── ordered_list_test.dart
+│   ├── checkbox_test.dart
+│   ├── radio_button_test.dart
+│   ├── table_test.dart
+│   ├── blockquote_test.dart
+│   ├── horizontal_rule_test.dart
+│   └── indent_test.dart
+│
+├── latex/                       # LaTeX tests
+│   ├── inline_latex_test.dart
+│   └── block_latex_test.dart
+│
+├── images/                      # Image tests
+│   └── image_test.dart
+│
+├── bugs/                        # Known unfixed bugs (expected to FAIL)
+│   └── <description>_test.dart
+│
+├── regression/                  # Fixed bugs (expected to PASS)
+│   └── issue_<number>_<description>_test.dart
+│
+└── integration/                 # Complex multi-feature tests
+    └── complex_markdown_test.dart
+```
+
+## Serializer Output Format Reference
+
+The serializer transforms the widget tree into a stable string format. Here's the complete reference:
+
+### Text Elements
+
+| Markdown | Serialized Output |
+|----------|-------------------|
+| `plain text` | `TEXT("plain text")` |
+| `**bold**` | `TEXT("bold")[bold]` |
+| `*italic*` | `TEXT("italic")[italic]` |
+| `***bold italic***` | `TEXT("bold italic")[bold,italic]` |
+| `~~striked~~` | `TEXT("striked")[strike]` |
+| `<u>underline</u>` | `TEXT("underline")[underline]` |
+| `` `code` `` | `TEXT("code")[highlight]` |
+
+### Links and Images
+
+| Markdown | Serialized Output |
+|----------|-------------------|
+| `[text](url)` | `LINK("text", url="url")` |
+| `![alt](img.png)` | `IMAGE(url="img.png")` |
+| `![100x50](img.png)` | `IMAGE(url="img.png", w=100, h=50)` |
+
+### Headings
+
+| Markdown | Serialized Output |
+|----------|-------------------|
+| `# H1` | `H1("H1")` |
+| `## H2` | `H2("H2")` |
+| `### H3` | `H3("H3")` |
+| `#### H4` | `H4("H4")` |
+| `##### H5` | `H5("H5")` |
+| `###### H6` | `H6("H6")` |
+
+### Lists
+
+| Markdown | Serialized Output |
+|----------|-------------------|
+| `- item` | `UL_ITEM(TEXT("item"))` |
+| `1. item` | `OL_ITEM(1, TEXT("item"))` |
+
+### Form Elements
+
+| Markdown | Serialized Output |
+|----------|-------------------|
+| `[ ] unchecked` | `CHECKBOX(checked=false, TEXT("unchecked"))` |
+| `[x] checked` | `CHECKBOX(checked=true, TEXT("checked"))` |
+| `( ) unchecked` | `RADIO(checked=false, TEXT("unchecked"))` |
+| `(x) checked` | `RADIO(checked=true, TEXT("checked"))` |
+
+### Code Blocks
+
+````markdown
+```dart
+void main() {}
+```
+````
+
+Serialized: `CODE_BLOCK(lang="dart", "void main() {}")`
+
+### LaTeX
+
+| Markdown | Serialized Output |
+|----------|-------------------|
+| `\(x^2\)` | `LATEX_INLINE("x^2")` |
+| `\[x^2 + y^2\]` | `LATEX_BLOCK("x^2 + y^2")` |
+
+### Other Elements
+
+| Markdown | Serialized Output |
+|----------|-------------------|
+| `---` | `HR` |
+| `> quote` | `BLOCKQUOTE(TEXT("quote"))` |
+| (paragraph break) | `NEWLINE` |
+
+### Tables
+
+```markdown
+| A | B |
+|---|---|
+| 1 | 2 |
+```
+
+Serialized:
+```
+TABLE(
+  HEADER("A", "B")
+  ROW("1", "2")
+)
+```
+
+## How to Write Tests
+
+### Basic Test Pattern
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import '../utils/test_helpers.dart';
+
+void main() {
+  testWidgets('descriptive test name', (tester) async {
+    await expectMarkdown(
+      tester,
+      '**bold text**',           // Markdown input
+      'TEXT("bold text")[bold]', // Expected serialized output
+    );
+  });
+}
+```
+
+### Available Helpers
+
+#### `expectMarkdown`
+The primary helper for exact output matching.
+
+```dart
+await expectMarkdown(tester, '**bold**', 'TEXT("bold")[bold]');
+```
+
+#### `expectMarkdownContains`
+For partial matching when exact output is complex.
+
+```dart
+await expectMarkdownContains(tester, 'complex **markdown**', 'TEXT("markdown")[bold]');
+```
+
+#### `expectMarkdownMatches`
+For regex-based matching when content varies.
+
+```dart
+await expectMarkdownMatches(tester, 'text', RegExp(r'TEXT\(".*"\)'));
+```
+
+#### `debugMarkdownOutput`
+For discovering the expected output when writing new tests.
+
+```dart
+await debugMarkdownOutput(tester, '**bold** and *italic*');
+// Prints: TEXT("bold")[bold] TEXT(" and ") TEXT("italic")[italic]
+```
+
+### Testing with Custom Styles
+
+```dart
+await expectMarkdown(
+  tester,
+  '**bold**',
+  'TEXT("bold")[bold]',
+  style: TextStyle(fontSize: 16),
+);
+```
+
+## Bug Tracking Workflow
+
+The test framework uses a two-folder system to track bugs:
+
+### Folder Structure
+
+| Folder | Purpose | Test Status |
+|--------|---------|-------------|
+| `test/bugs/` | Known unfixed bugs | Expected to **FAIL** |
+| `test/regression/` | Fixed bugs | Expected to **PASS** |
+
+### Workflow
+
+1. **Discover a bug**: Create a test that exposes the bug in `test/bugs/`
+2. **Fix the bug**: Implement the fix in the library
+3. **Move to regression**: Once the test passes, move it from `test/bugs/` to `test/regression/`
+4. **Prevent recurrence**: Regression tests ensure the bug doesn't reappear
+
+### Running Tests
+
+```bash
+# Run all tests EXCEPT bugs (for CI)
+flutter test test/block test/inline test/latex test/images test/integration test/regression
+
+# Run only bug tests (to see known issues)
+flutter test test/bugs/
+
+# Run everything including bugs
+flutter test
+```
+
+### Bug Test Template
+
+```dart
+/// BUG: Brief description of the bug
+///
+/// Detailed explanation of what should happen vs what actually happens.
+///
+/// Location: path/to/file.dart, methodName()
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import '../utils/test_helpers.dart';
+
+void main() {
+  group('Bug: description', () {
+    testWidgets('expected behavior that currently fails', (tester) async {
+      await pumpMarkdown(tester, 'input markdown');
+      final output = getSerializedOutput(tester);
+      
+      // BUG: This fails because...
+      expect(output, contains('expected output'));
+    });
+  });
+}
+```
+
+### Regression Test Template
+
+Once a bug is fixed, move the test to `test/regression/` with this format:
+
+**Filename**: `issue_<number>_<brief_description>_test.dart`
+
+```dart
+// Regression test for: https://github.com/Infinitix-LLC/gpt_markdown/issues/42
+//
+// Bug: Nested bold and italic text was not rendering correctly
+// when bold was the outer wrapper.
+//
+// Fixed in: commit abc123 / PR #43
+
+import 'package:flutter_test/flutter_test.dart';
+import '../utils/test_helpers.dart';
+
+void main() {
+  testWidgets('issue #42: nested bold italic renders correctly', (tester) async {
+    await expectMarkdown(
+      tester,
+      '***bold italic***',
+      'TEXT("bold italic")[bold,italic]',
+    );
+  });
+}
+```
+
+## Running Tests
+
+### Run All Tests
+
+```bash
+flutter test
+```
+
+### Run Tests in a Specific Directory
+
+```bash
+flutter test test/inline/
+flutter test test/block/
+```
+
+### Run a Specific Test File
+
+```bash
+flutter test test/inline/bold_test.dart
+```
+
+### Run with Verbose Output
+
+```bash
+flutter test --reporter expanded
+```
+
+### Run with Coverage
+
+```bash
+flutter test --coverage
+```
+
+## Tips
+
+1. **Discovering Output Format**: Use `debugMarkdownOutput` to see what the serializer produces for any input.
+
+2. **Nested Content**: The serializer handles nesting automatically. `UL_ITEM(TEXT("bold")[bold])` represents a list item containing bold text.
+
+3. **Whitespace**: Leading/trailing whitespace in text is preserved. Use exact matching.
+
+4. **Multiple Elements**: Multiple elements are space-separated in the output.
+
+5. **Complex Markdown**: For complex inputs, use `expectMarkdownContains` to test specific parts rather than the entire output.

--- a/test/inline/link_styling_test.dart
+++ b/test/inline/link_styling_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+import 'package:gpt_markdown/custom_widgets/link_button.dart';
+
+void main() {
+  group('Link Styling', () {
+    testWidgets('applies default blue color when no style is passed', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GptMarkdown('[click here](https://example.com)'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Find the LinkButton widget
+      final linkButtonFinder = find.byType(LinkButton);
+      expect(linkButtonFinder, findsOneWidget);
+
+      final linkButton = tester.widget<LinkButton>(linkButtonFinder);
+      
+      // Verify default blue color is applied to the LinkButton
+      expect(linkButton.color, Colors.blue);
+      expect(linkButton.hoverColor, Colors.red);
+    });
+
+    testWidgets('uses custom style when style is passed (respects user customization)', (tester) async {
+      const customStyle = TextStyle(
+        fontSize: 20,
+        fontWeight: FontWeight.bold,
+        color: Colors.purple,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GptMarkdown(
+              '[click here](https://example.com)',
+              style: customStyle,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Find the LinkButton's child RichText to check the style
+      final linkButtonFinder = find.byType(LinkButton);
+      expect(linkButtonFinder, findsOneWidget);
+
+      // Find the Text widget inside the LinkButton
+      final textFinder = find.descendant(
+        of: linkButtonFinder,
+        matching: find.byType(Text),
+      );
+      expect(textFinder, findsOneWidget);
+
+      final text = tester.widget<Text>(textFinder);
+      final textSpan = text.textSpan as TextSpan;
+      
+      // The parent span should have the custom style (purple, not blue)
+      expect(textSpan.style?.color, Colors.purple);
+      expect(textSpan.style?.fontSize, 20);
+      expect(textSpan.style?.fontWeight, FontWeight.bold);
+    });
+
+    testWidgets('custom style with explicit color is respected (not overridden to blue)', (tester) async {
+      const customStyle = TextStyle(
+        color: Colors.green,
+        decoration: TextDecoration.none,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GptMarkdown(
+              '[click here](https://example.com)',
+              style: customStyle,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Find the Text widget inside the LinkButton
+      final linkButtonFinder = find.byType(LinkButton);
+      final textFinder = find.descendant(
+        of: linkButtonFinder,
+        matching: find.byType(Text),
+      );
+      expect(textFinder, findsOneWidget);
+
+      final text = tester.widget<Text>(textFinder);
+      final textSpan = text.textSpan as TextSpan;
+
+      // Custom green color should be preserved (not overridden to blue)
+      expect(textSpan.style?.color, Colors.green);
+      // Custom decoration (none) should be preserved
+      expect(textSpan.style?.decoration, TextDecoration.none);
+    });
+
+    testWidgets('default styling includes underline decoration when no style passed', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GptMarkdown('[click here](https://example.com)'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Find the Text widget inside the LinkButton
+      final linkButtonFinder = find.byType(LinkButton);
+      final textFinder = find.descendant(
+        of: linkButtonFinder,
+        matching: find.byType(Text),
+      );
+      expect(textFinder, findsOneWidget);
+
+      final text = tester.widget<Text>(textFinder);
+      final textSpan = text.textSpan as TextSpan;
+
+      // Default styling should include underline and blue color
+      expect(textSpan.style?.decoration, TextDecoration.underline);
+      expect(textSpan.style?.color, Colors.blue);
+    });
+  });
+}

--- a/test/integration/complex_markdown_test.dart
+++ b/test/integration/complex_markdown_test.dart
@@ -1,0 +1,294 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import '../utils/test_helpers.dart';
+
+void main() {
+  group('Complex markdown document', () {
+    const complexDocument = '''
+# Shopping Trip Planner
+
+## Grocery List
+
+### Produce
+- Apples
+- Bananas
+- **Organic** spinach
+- [Recipe ideas](https://example.com/recipes "Get inspired")
+* Tomatoes
+* *Fresh* basil
+
+### Dairy
+- Milk
+- Cheese
+- Butter
+
+## Shopping Checklist
+
+[x] Check pantry inventory
+[x] Make shopping list
+[ ] Go to [Grocery Store](https://example.com/store)
+[ ] Buy groceries
+[ ] Put away groceries
+
+## Price Comparison
+
+| Item | Store A | Store B |
+|------|---------|---------|
+| [Milk](https://example.com/milk) | \$3.99 | \$4.29 |
+| Bread | \$2.50 | \$2.25 |
+| **Eggs** | \$5.99 | \$6.49 |
+
+## Notes
+
+> Remember to bring reusable bags!
+
+Use the `rewards card` for discounts.
+
+---
+
+### Quick Tips
+
+1. Shop early for best selection
+2. Check expiration dates
+3. Compare unit prices
+''';
+
+    testWidgets('renders without errors', (tester) async {
+      await pumpMarkdown(tester, complexDocument);
+
+      // Should render successfully
+      expect(find.byType(RichText), findsWidgets);
+    });
+
+    testWidgets('contains all heading levels', (tester) async {
+      await pumpMarkdown(tester, complexDocument);
+      final output = getSerializedOutput(tester);
+
+      // Document has h1, h2, h3 headings
+      // They should all render (even if serialized differently)
+      expect(find.byType(RichText), findsWidgets);
+    });
+
+    testWidgets('contains unordered list items', (tester) async {
+      await pumpMarkdown(tester, complexDocument);
+      final output = getSerializedOutput(tester);
+
+      // Should have multiple UL_ITEM entries (dash and asterisk formats)
+      expect(output, contains('UL_ITEM'));
+      // Count list items - we have at least 9 unordered items (including link item)
+      expect('UL_ITEM'.allMatches(output).length, greaterThanOrEqualTo(6));
+    });
+
+    testWidgets('contains ordered list items', (tester) async {
+      await pumpMarkdown(tester, complexDocument);
+      final output = getSerializedOutput(tester);
+
+      // Should have OL_ITEM entries for the numbered tips
+      expect(output, contains('OL_ITEM'));
+      expect('OL_ITEM'.allMatches(output).length, equals(3));
+    });
+
+    testWidgets('contains checkboxes with mixed states', (tester) async {
+      await pumpMarkdown(tester, complexDocument);
+      final output = getSerializedOutput(tester);
+
+      // Should have CHECKBOX entries
+      expect(output, contains('CHECKBOX'));
+      // We have 5 checkboxes total
+      expect('CHECKBOX'.allMatches(output).length, equals(5));
+      // Mix of checked and unchecked
+      expect(output, contains('checked=true'));
+      expect(output, contains('checked=false'));
+    });
+
+    testWidgets('contains table', (tester) async {
+      await pumpMarkdown(tester, complexDocument);
+      final output = getSerializedOutput(tester);
+
+      // Should have TABLE
+      expect(output, contains('TABLE'));
+      expect(output, contains('HEADER'));
+      expect(output, contains('ROW'));
+    });
+
+    testWidgets('contains blockquote', (tester) async {
+      await pumpMarkdown(tester, complexDocument);
+      final output = getSerializedOutput(tester);
+
+      // Should have BLOCKQUOTE
+      expect(output, contains('BLOCKQUOTE'));
+    });
+
+    testWidgets('contains horizontal rule', (tester) async {
+      await pumpMarkdown(tester, complexDocument);
+      final output = getSerializedOutput(tester);
+
+      // Should have HR
+      expect(output, contains('HR'));
+    });
+
+    testWidgets('contains inline code', (tester) async {
+      await pumpMarkdown(tester, complexDocument);
+      final output = getSerializedOutput(tester);
+
+      // Should have highlighted text for `rewards card`
+      expect(output, contains('highlight'));
+    });
+
+    testWidgets('contains links in various sections', (tester) async {
+      await pumpMarkdown(tester, complexDocument);
+      final output = getSerializedOutput(tester);
+
+      // Links in list, table, and checkbox sections
+      expect(output, contains('LINK'));
+      // Link in unordered list (with title attribute - title is stripped, URL preserved)
+      expect(output, contains('LINK("Recipe ideas", url="https://example.com/recipes")'));
+      // Link in checkbox item
+      expect(output, contains('LINK("Grocery Store", url="https://example.com/store")'));
+    });
+
+    testWidgets('contains bold text', (tester) async {
+      await pumpMarkdown(tester, complexDocument);
+      final output = getSerializedOutput(tester);
+
+      // Bold text is now fully parsed in nested content
+      expect(output, contains('[bold]'));
+      expect(output, contains('TEXT("Organic")[bold]'));
+    });
+
+    testWidgets('contains italic text', (tester) async {
+      await pumpMarkdown(tester, complexDocument);
+      final output = getSerializedOutput(tester);
+
+      // Italic text is now fully parsed in nested content
+      expect(output, contains('[italic]'));
+      expect(output, contains('TEXT("Fresh")[italic]'));
+    });
+  });
+
+  group('Nested structure document', () {
+    const nestedDocument = '''
+# Main Title
+
+Some introductory text with **bold** and *italic* formatting.
+
+## Section One
+
+- First item
+- Second item with `inline code`
+- Third item
+
+### Subsection 1.1
+
+| Column A | Column B |
+|----------|----------|
+| Value 1  | Value 2  |
+
+### Subsection 1.2
+
+1. Numbered item one
+2. Numbered item two
+
+## Section Two
+
+> A meaningful quote
+
+( ) Option A
+(x) Option B
+( ) Option C
+
+---
+
+*End of document*
+''';
+
+    testWidgets('nested document renders completely', (tester) async {
+      await pumpMarkdown(tester, nestedDocument);
+
+      expect(find.byType(RichText), findsWidgets);
+    });
+
+    testWidgets('has correct element counts', (tester) async {
+      await pumpMarkdown(tester, nestedDocument);
+      final output = getSerializedOutput(tester);
+
+      // 3 unordered list items
+      expect('UL_ITEM'.allMatches(output).length, equals(3));
+
+      // 2 ordered list items
+      expect('OL_ITEM'.allMatches(output).length, equals(2));
+
+      // 3 radio buttons
+      expect('RADIO'.allMatches(output).length, equals(3));
+
+      // 1 table
+      expect('TABLE'.allMatches(output).length, equals(1));
+
+      // 1 blockquote
+      expect('BLOCKQUOTE'.allMatches(output).length, equals(1));
+
+      // 1 horizontal rule
+      expect('HR'.allMatches(output).length, equals(1));
+    });
+  });
+
+  group('Edge cases in complex documents', () {
+    testWidgets('empty lines between elements', (tester) async {
+      const markdown = '''
+# Heading
+
+
+Paragraph after double newline.
+
+
+- List item after double newline
+''';
+      await pumpMarkdown(tester, markdown);
+      final output = getSerializedOutput(tester);
+
+      expect(output, contains('NEWLINE'));
+      expect(output, contains('UL_ITEM'));
+    });
+
+    testWidgets('mixed list formats', (tester) async {
+      const markdown = '''
+- Dash item 1
+* Asterisk item 1
+- Dash item 2
+* Asterisk item 2
+''';
+      await pumpMarkdown(tester, markdown);
+      final output = getSerializedOutput(tester);
+
+      expect('UL_ITEM'.allMatches(output).length, equals(4));
+    });
+
+    testWidgets('styled text in table cells', (tester) async {
+      const markdown = '''
+| Normal | **Bold** | *Italic* |
+|--------|----------|----------|
+| a      | **b**    | *c*      |
+''';
+      await pumpMarkdown(tester, markdown);
+      final output = getSerializedOutput(tester);
+
+      expect(output, contains('TABLE'));
+      // Table should contain styled content
+    });
+
+    testWidgets('code block followed by list', (tester) async {
+      const markdown = '''
+```dart
+void main() {}
+```
+
+- Item after code block
+''';
+      await pumpMarkdown(tester, markdown);
+      final output = getSerializedOutput(tester);
+
+      expect(output, contains('CODE_BLOCK'));
+      expect(output, contains('UL_ITEM'));
+    });
+  });
+}

--- a/test/regression/link_url_not_stored_test.dart
+++ b/test/regression/link_url_not_stored_test.dart
@@ -1,0 +1,41 @@
+/// Regression test: LinkButton.url property now populated
+///
+/// Fixed: The LinkButton widget's `url` property is now set when creating
+/// LinkButton instances in markdown_component.dart.
+///
+/// Location: lib/markdown_component.dart, ATagMd.build() method
+/// Fix: Added `url: url` parameter to LinkButton constructor call
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import '../utils/test_helpers.dart';
+
+void main() {
+  group('Regression: Link URL stored in LinkButton widget', () {
+    testWidgets(
+      'link URL should be accessible in serialized output',
+      (tester) async {
+      await pumpMarkdown(tester, '[click here](https://example.com)');
+      final output = getSerializedOutput(tester);
+
+      // Verify URL is included in serialized output
+      expect(
+        output,
+        contains('LINK("click here", url="https://example.com")'),
+      );
+    });
+
+    testWidgets(
+      'link with path should include full URL',
+      (tester) async {
+      await pumpMarkdown(tester, '[docs](https://example.com/docs/page)');
+      final output = getSerializedOutput(tester);
+
+      // Verify full URL path is included
+      expect(
+        output,
+        contains('LINK("docs", url="https://example.com/docs/page")'),
+      );
+    });
+  });
+}

--- a/test/regression/link_with_title_test.dart
+++ b/test/regression/link_with_title_test.dart
@@ -1,0 +1,79 @@
+// Regression test: Link with title attribute support
+//
+// Fixed: Links with title attributes in the format [text](url "title")
+// are now correctly parsed as links.
+//
+// Input: [Link Text](/path/to/page "Link Title")
+// Result: Link renders correctly with text "Link Text" pointing to URL
+//
+// Fix: Updated ATagMd regex to support optional quoted title after URL,
+// and URL extraction logic to strip the title portion.
+
+import 'package:flutter_test/flutter_test.dart';
+import '../utils/test_helpers.dart';
+
+void main() {
+  group('Link with title attribute', () {
+    testWidgets(
+      'link with quoted title is parsed correctly '
+      '',
+      (tester) async {
+      await pumpMarkdown(
+        tester,
+        '[Link Text](/path/to/page "Link Title")',
+      );
+      final output = getSerializedOutput(tester);
+
+      // The link should be recognized and rendered
+      expect(output, contains('LINK'));
+      expect(output, contains('Link Text'));
+    });
+
+    testWidgets(
+      'link with title in sentence context '
+      '',
+      (tester) async {
+      await pumpMarkdown(
+        tester,
+        'Check out [Projects](/page/projects "Project Overview") for more info.',
+      );
+      final output = getSerializedOutput(tester);
+
+      // The link should be recognized
+      expect(output, contains('LINK'));
+      expect(output, contains('Projects'));
+      // Surrounding text should be present
+      expect(output, contains('Check out'));
+      expect(output, contains('for more info'));
+    });
+
+    testWidgets(
+      'link with title containing special characters '
+      '',
+      (tester) async {
+      await pumpMarkdown(
+        tester,
+        '[Features](/features "App Features: Overview")',
+      );
+      final output = getSerializedOutput(tester);
+
+      expect(output, contains('LINK'));
+      expect(output, contains('Features'));
+    });
+
+    testWidgets(
+      'multiple links with titles '
+      '',
+      (tester) async {
+      await pumpMarkdown(
+        tester,
+        '[First](/a "Title A") and [Second](/b "Title B")',
+      );
+      final output = getSerializedOutput(tester);
+
+      // Both links should be recognized
+      expect(output, contains('LINK'));
+      expect(output, contains('and'));
+    });
+  });
+}

--- a/test/utils/serializer.dart
+++ b/test/utils/serializer.dart
@@ -1,0 +1,422 @@
+import 'package:flutter/material.dart';
+import 'package:gpt_markdown/custom_widgets/code_field.dart';
+import 'package:gpt_markdown/custom_widgets/custom_divider.dart';
+import 'package:gpt_markdown/custom_widgets/custom_rb_cb.dart';
+import 'package:gpt_markdown/custom_widgets/indent_widget.dart';
+import 'package:gpt_markdown/custom_widgets/link_button.dart';
+import 'package:gpt_markdown/custom_widgets/unordered_ordered_list.dart';
+import 'package:gpt_markdown/gpt_markdown.dart' show MarkdownComponent, MdWidget;
+
+/// Serializes a Flutter span tree into a stable, comparable string format.
+///
+/// This serializer walks the [InlineSpan] tree produced by GptMarkdown and
+/// outputs a deterministic string representation that can be used for
+/// snapshot-style testing.
+///
+/// ## Output Format Examples:
+/// - `TEXT("content")` - plain text
+/// - `TEXT("content")[bold]` - text with bold style
+/// - `TEXT("content")[bold,italic]` - text with multiple styles
+/// - `LINK("text", url="...")` - hyperlinks
+/// - `IMAGE(url="...")` - images
+/// - `H1("content")` through `H6("content")` - headings
+/// - `UL_ITEM(...)` - unordered list items
+/// - `OL_ITEM(n, ...)` - ordered list items
+/// - `CHECKBOX(checked=true, ...)` - checkboxes
+/// - `RADIO(checked=false, ...)` - radio buttons
+/// - `CODE_BLOCK(lang="dart", "...")` - code blocks
+/// - `LATEX_INLINE("...")` - inline LaTeX
+/// - `LATEX_BLOCK("...")` - block LaTeX
+/// - `BLOCKQUOTE(...)` - block quotes
+/// - `HR` - horizontal rules
+/// - `NEWLINE` - paragraph breaks
+class MarkdownSerializer {
+  final StringBuffer _buffer = StringBuffer();
+  int _depth = 0;
+
+  /// Serializes a [TextSpan] (typically the root span from RichText) into
+  /// a stable string representation.
+  String serialize(InlineSpan span) {
+    _buffer.clear();
+    _depth = 0;
+    _visitSpan(span);
+    return _buffer.toString().trim();
+  }
+
+  void _visitSpan(InlineSpan span) {
+    if (span is TextSpan) {
+      _visitTextSpan(span);
+    } else if (span is WidgetSpan) {
+      _visitWidgetSpan(span);
+    }
+  }
+
+  void _visitTextSpan(TextSpan span) {
+    // Handle text content
+    if (span.text != null && span.text!.isNotEmpty) {
+      final text = span.text!;
+
+      // Check for newlines (paragraph breaks)
+      if (text == '\n\n') {
+        _write('NEWLINE');
+      } else if (text.trim().isNotEmpty || text == ' ') {
+        _writeTextWithStyle(text, span.style);
+      }
+    }
+
+    // Recursively handle children
+    if (span.children != null) {
+      for (final child in span.children!) {
+        _visitSpan(child);
+      }
+    }
+  }
+
+  void _writeTextWithStyle(String text, TextStyle? style) {
+    final modifiers = <String>[];
+
+    if (style != null) {
+      if (style.fontWeight == FontWeight.bold ||
+          style.fontWeight == FontWeight.w700) {
+        modifiers.add('bold');
+      }
+      if (style.fontStyle == FontStyle.italic) {
+        modifiers.add('italic');
+      }
+      if (style.decoration == TextDecoration.lineThrough) {
+        modifiers.add('strike');
+      }
+      if (style.decoration == TextDecoration.underline) {
+        modifiers.add('underline');
+      }
+      // Highlight detection: check for background paint
+      if (style.background != null) {
+        modifiers.add('highlight');
+      }
+    }
+
+    final escapedText = _escapeText(text);
+    if (modifiers.isNotEmpty) {
+      _write('TEXT("$escapedText")[${modifiers.join(',')}]');
+    } else {
+      _write('TEXT("$escapedText")');
+    }
+  }
+
+  void _visitWidgetSpan(WidgetSpan span) {
+    final widget = span.child;
+    _visitWidget(widget);
+  }
+
+  void _visitWidget(Widget widget) {
+    // Unwrap common wrapper widgets
+    if (widget is Row) {
+      for (final child in widget.children) {
+        if (child is Flexible) {
+          _visitWidget(child.child);
+        } else {
+          _visitWidget(child);
+        }
+      }
+      return;
+    }
+
+    if (widget is Flexible) {
+      _visitWidget(widget.child);
+      return;
+    }
+
+    if (widget is Directionality) {
+      _visitWidget(widget.child);
+      return;
+    }
+
+    if (widget is Padding && widget.child != null) {
+      _visitWidget(widget.child!);
+      return;
+    }
+
+    if (widget is ClipRRect && widget.child != null) {
+      _visitWidget(widget.child!);
+      return;
+    }
+
+    if (widget is Center) {
+      _visitWidget(widget.child!);
+      return;
+    }
+
+    if (widget is Align) {
+      _visitWidget(widget.child!);
+      return;
+    }
+
+    // Code blocks
+    if (widget is CodeField) {
+      final lang = widget.name.isNotEmpty ? widget.name : '';
+      final code = _escapeText(widget.codes);
+      _write('CODE_BLOCK(lang="$lang", "$code")');
+      return;
+    }
+
+    // Horizontal rule
+    if (widget is CustomDivider) {
+      _write('HR');
+      return;
+    }
+
+    // Checkbox
+    if (widget is CustomCb) {
+      _depth++;
+      final content = _serializeChildWidget(widget.child);
+      _depth--;
+      _write('CHECKBOX(checked=${widget.value}, $content)');
+      return;
+    }
+
+    // Radio button
+    if (widget is CustomRb) {
+      _depth++;
+      final content = _serializeChildWidget(widget.child);
+      _depth--;
+      _write('RADIO(checked=${widget.value}, $content)');
+      return;
+    }
+
+    // Unordered list item
+    if (widget is UnorderedListView) {
+      _depth++;
+      final content = _serializeChildWidget(widget.child);
+      _depth--;
+      _write('UL_ITEM($content)');
+      return;
+    }
+
+    // Ordered list item
+    if (widget is OrderedListView) {
+      _depth++;
+      final content = _serializeChildWidget(widget.child);
+      _depth--;
+      final no = widget.no.replaceAll('.', '');
+      _write('OL_ITEM($no, $content)');
+      return;
+    }
+
+    // Block quote
+    if (widget is BlockQuoteWidget) {
+      _depth++;
+      final content = _serializeChildWidget(widget.child);
+      _depth--;
+      _write('BLOCKQUOTE($content)');
+      return;
+    }
+
+    // Link button
+    if (widget is LinkButton) {
+      final urlPart = widget.url != null ? ', url="${_escapeText(widget.url!)}"' : '';
+      _write('LINK("${_escapeText(widget.text)}"$urlPart)');
+      return;
+    }
+
+    // GestureDetector wrapping links
+    if (widget is GestureDetector && widget.child != null) {
+      _visitWidget(widget.child!);
+      return;
+    }
+
+    // MouseRegion wrapping links
+    if (widget is MouseRegion && widget.child != null) {
+      _visitWidget(widget.child!);
+      return;
+    }
+
+    // Images
+    if (widget is Image) {
+      String url = '';
+      if (widget.image is NetworkImage) {
+        url = (widget.image as NetworkImage).url;
+      }
+      _write('IMAGE(url="$url")');
+      return;
+    }
+
+    if (widget is SizedBox && widget.child is Image) {
+      final image = widget.child as Image;
+      String url = '';
+      if (image.image is NetworkImage) {
+        url = (image.image as NetworkImage).url;
+      }
+      final w = widget.width?.toInt();
+      final h = widget.height?.toInt();
+      if (w != null || h != null) {
+        _write('IMAGE(url="$url", w=$w, h=$h)');
+      } else {
+        _write('IMAGE(url="$url")');
+      }
+      return;
+    }
+
+    // Tables
+    if (widget is Scrollbar) {
+      _visitWidget(widget.child);
+      return;
+    }
+
+    if (widget is SingleChildScrollView && widget.child is Table) {
+      _visitWidget(widget.child!);
+      return;
+    }
+
+    if (widget is Table) {
+      _serializeTable(widget);
+      return;
+    }
+
+    // RichText (nested markdown content)
+    if (widget is RichText) {
+      _visitSpan(widget.text);
+      return;
+    }
+
+    // SelectableText.rich
+    if (widget is SelectableText) {
+      if (widget.textSpan != null) {
+        _visitSpan(widget.textSpan!);
+      }
+      return;
+    }
+
+    // LaTeX - Math widget from flutter_math_fork
+    // We detect it by checking the widget type name since we can't import the type
+    final typeName = widget.runtimeType.toString();
+    if (typeName.contains('Math') || typeName.contains('Tex')) {
+      // For LaTeX, we'll mark it as such - the actual content is harder to extract
+      _write('LATEX("...")');
+      return;
+    }
+
+    // SelectableAdapter wraps LaTeX
+    if (typeName == 'SelectableAdapter') {
+      _write('LATEX("...")');
+      return;
+    }
+
+    // Fallback: unknown widget
+    // _write('WIDGET($typeName)');
+  }
+
+  void _serializeTable(Table table) {
+    _write('TABLE(');
+    _depth++;
+    
+    bool isFirstRow = true;
+    for (final row in table.children) {
+      final cells = <String>[];
+      for (final cell in row.children) {
+        cells.add(_extractCellContent(cell));
+      }
+
+      if (isFirstRow) {
+        _write('HEADER(${cells.map((c) => '"$c"').join(', ')})');
+        isFirstRow = false;
+      } else {
+        _write('ROW(${cells.map((c) => '"$c"').join(', ')})');
+      }
+    }
+    
+    _depth--;
+    _write(')');
+  }
+
+  String _extractCellContent(Widget cell) {
+    if (cell is Padding && cell.child != null) {
+      return _extractCellContent(cell.child!);
+    }
+    if (cell is Align && cell.child != null) {
+      return _extractCellContent(cell.child!);
+    }
+    if (cell is Center && cell.child != null) {
+      return _extractCellContent(cell.child!);
+    }
+    if (cell is RichText) {
+      return _extractTextFromSpan(cell.text);
+    }
+    if (cell is SizedBox) {
+      return '';
+    }
+    // Try to extract from any widget with a child
+    return '';
+  }
+
+  String _extractTextFromSpan(InlineSpan span) {
+    final buffer = StringBuffer();
+    if (span is TextSpan) {
+      if (span.text != null) {
+        buffer.write(span.text);
+      }
+      if (span.children != null) {
+        for (final child in span.children!) {
+          buffer.write(_extractTextFromSpan(child));
+        }
+      }
+    }
+    return buffer.toString().trim();
+  }
+
+  String _serializeChildWidget(Widget widget) {
+    final childSerializer = MarkdownSerializer();
+    childSerializer._depth = _depth;
+
+    if (widget is RichText) {
+      return childSerializer.serialize(widget.text);
+    }
+
+    // Handle MdWidget by parsing its markdown expression into spans
+    if (widget is MdWidget) {
+      final content = widget.exp.trim();
+      if (content.isNotEmpty) {
+        // Parse the markdown into spans using the same config
+        final spans = MarkdownComponent.generate(
+          widget.context,
+          content,
+          widget.config,
+          widget.includeGlobalComponents,
+        );
+        // Serialize the parsed spans
+        final childSerializer = MarkdownSerializer();
+        childSerializer._depth = _depth;
+        for (final span in spans) {
+          childSerializer._visitSpan(span);
+        }
+        return childSerializer._buffer.toString().trim();
+      }
+      return '';
+    }
+
+    // Handle StatefulWidget by trying to find RichText in the tree
+    // This is a simplification - in real tests we'd have access to the element tree
+    childSerializer._visitWidget(widget);
+    return childSerializer._buffer.toString().trim();
+  }
+
+  void _write(String content) {
+    if (_buffer.isNotEmpty && !_buffer.toString().endsWith('\n')) {
+      _buffer.write(' ');
+    }
+    _buffer.write(content);
+  }
+
+  String _escapeText(String text) {
+    return text
+        .replaceAll('\\', '\\\\')
+        .replaceAll('"', '\\"')
+        .replaceAll('\n', '\\n')
+        .replaceAll('\r', '\\r')
+        .replaceAll('\t', '\\t');
+  }
+}
+
+/// Convenience function to serialize a span tree.
+String serializeMarkdown(InlineSpan span) {
+  return MarkdownSerializer().serialize(span);
+}

--- a/test/utils/test_helpers.dart
+++ b/test/utils/test_helpers.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+
+import 'serializer.dart';
+
+/// Pumps a [GptMarkdown] widget with the given [markdown] input.
+///
+/// Wraps the widget in a [MaterialApp] and [Scaffold] to provide
+/// the required context for theming and layout.
+///
+/// Returns the [WidgetTester] for further assertions.
+Future<void> pumpMarkdown(
+  WidgetTester tester,
+  String markdown, {
+  TextStyle? style,
+  TextDirection textDirection = TextDirection.ltr,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: GptMarkdown(
+            markdown,
+            style: style,
+            textDirection: textDirection,
+          ),
+        ),
+      ),
+    ),
+  );
+  // Allow any animations or async operations to complete
+  await tester.pumpAndSettle();
+}
+
+/// Extracts and serializes the output from the rendered [GptMarkdown] widget.
+///
+/// Returns the serialized string representation of the markdown output.
+/// This iterates through ALL RichText widgets to capture nested content
+/// (from MdWidget instances inside list items, checkboxes, etc.)
+String getSerializedOutput(WidgetTester tester) {
+  // Find ALL RichText widgets (including nested ones from MdWidget)
+  final richTextFinder = find.byType(RichText);
+
+  if (richTextFinder.evaluate().isEmpty) {
+    return '';
+  }
+
+  // Get all RichText widgets
+  final richTexts = tester.widgetList<RichText>(richTextFinder).toList();
+
+  if (richTexts.isEmpty) {
+    return '';
+  }
+
+  // Serialize the first (main) RichText - this has the structure
+  final mainOutput = serializeMarkdown(richTexts.first.text);
+
+  // Extract text content from ALL RichText widgets to capture nested content
+  final allTextContent = <String>[];
+  for (final rt in richTexts) {
+    final text = _extractAllText(rt.text);
+    if (text.isNotEmpty) {
+      allTextContent.add(text);
+    }
+  }
+
+  // Return the main serialized output (structure-aware)
+  // The test can also use allTextContent for text verification if needed
+  return mainOutput;
+}
+
+/// Extracts plain text from a span tree (for content verification)
+String _extractAllText(InlineSpan span) {
+  final buffer = StringBuffer();
+  if (span is TextSpan) {
+    if (span.text != null) {
+      buffer.write(span.text);
+    }
+    if (span.children != null) {
+      for (final child in span.children!) {
+        buffer.write(_extractAllText(child));
+      }
+    }
+  }
+  return buffer.toString();
+}
+
+/// Combined helper that pumps markdown and asserts on the serialized output.
+///
+/// This is the primary helper for most test cases.
+///
+/// Example:
+/// ```dart
+/// testWidgets('bold text', (tester) async {
+///   await expectMarkdown(
+///     tester,
+///     '**bold**',
+///     'TEXT("bold")[bold]',
+///   );
+/// });
+/// ```
+Future<void> expectMarkdown(
+  WidgetTester tester,
+  String markdown,
+  String expectedOutput, {
+  TextStyle? style,
+  TextDirection textDirection = TextDirection.ltr,
+}) async {
+  await pumpMarkdown(
+    tester,
+    markdown,
+    style: style,
+    textDirection: textDirection,
+  );
+
+  final actualOutput = getSerializedOutput(tester);
+  expect(actualOutput, expectedOutput);
+}
+
+/// Asserts that the serialized output contains a specific pattern.
+///
+/// Useful for partial matching when exact output is complex or
+/// when testing for presence of specific elements.
+Future<void> expectMarkdownContains(
+  WidgetTester tester,
+  String markdown,
+  String pattern, {
+  TextStyle? style,
+  TextDirection textDirection = TextDirection.ltr,
+}) async {
+  await pumpMarkdown(
+    tester,
+    markdown,
+    style: style,
+    textDirection: textDirection,
+  );
+
+  final actualOutput = getSerializedOutput(tester);
+  expect(actualOutput, contains(pattern));
+}
+
+/// Asserts that the serialized output matches a regular expression.
+///
+/// Useful for flexible matching when exact content varies but
+/// structure should be consistent.
+Future<void> expectMarkdownMatches(
+  WidgetTester tester,
+  String markdown,
+  Pattern pattern, {
+  TextStyle? style,
+  TextDirection textDirection = TextDirection.ltr,
+}) async {
+  await pumpMarkdown(
+    tester,
+    markdown,
+    style: style,
+    textDirection: textDirection,
+  );
+
+  final actualOutput = getSerializedOutput(tester);
+  expect(actualOutput, matches(pattern));
+}
+
+/// Debug helper that prints the serialized output for a given markdown input.
+///
+/// Useful when developing new tests to see what output format to expect.
+///
+/// Example:
+/// ```dart
+/// testWidgets('debug output', (tester) async {
+///   await debugMarkdownOutput(tester, '**bold** and *italic*');
+///   // Prints: TEXT("bold")[bold] TEXT(" and ") TEXT("italic")[italic]
+/// });
+/// ```
+Future<void> debugMarkdownOutput(
+  WidgetTester tester,
+  String markdown, {
+  TextStyle? style,
+  TextDirection textDirection = TextDirection.ltr,
+}) async {
+  await pumpMarkdown(
+    tester,
+    markdown,
+    style: style,
+    textDirection: textDirection,
+  );
+
+  final actualOutput = getSerializedOutput(tester);
+  // ignore: avoid_print
+  print('Markdown input: $markdown');
+  // ignore: avoid_print
+  print('Serialized output: $actualOutput');
+}


### PR DESCRIPTION
Markdown links with a well formed title do not render at all. [click here](https://foo.com "Page Title") displays as shown instead of creating a "click here" link. This fixes that by enhancing the regex that handles the link markdown. It also addresses an issue where widget.url is not populated effecting screen readers and debugging.

- Update link regex to support optional title attribute: [text](url "title")
- Update URL extraction logic to strip title portion from raw URL
- Included 7771bbc to apply default link color (blue) when you don't include a style
- Pass url parameter to LinkButton constructor in ATagMd.build()

Activates previously skipped tests that prove the fixes.