### PR TITLE
fix: bump flutter_math_fork to ^0.7.4 for Flutter 3.35+ compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_math_fork: ^0.7.3
+  flutter_math_fork: ^0.7.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Problem

Users on Flutter 3.35+ (Dart 3.9) get a build failure caused by `flutter_math_fork: ^0.7.3` being incompatible with the newer toolchain.

Reported in #101 and #112.

## Fix

Bump the dependency constraint from `^0.7.3` to `^0.7.4`:

```yaml
# Before
flutter_math_fork: ^0.7.3

# After
flutter_math_fork: ^0.7.4
```

`flutter_math_fork` 0.7.4 maintains full API compatibility — this is a drop-in version bump with no code changes required.

## Verification

```bash
flutter pub get   # resolves cleanly on Flutter 3.35+
flutter build apk # no errors
```

Closes #101
Closes #112