### PR TITLE
fix: respect user style for ordered list numbers (remove hardcoded ultra-thin font weight)

### DIFF
--- a/lib/markdown_component.dart
+++ b/lib/markdown_component.dart
@@ -442,9 +442,7 @@ class OrderedList extends BlockMd {
         OrderedListView(
           no: "$no.",
           textDirection: config.textDirection,
-          style: (config.style ?? const TextStyle()).copyWith(
-            fontWeight: FontWeight.w100,
-          ),
+          style: config.style,
           child: child,
         );
   }


### PR DESCRIPTION
## Problem

Ordered list numbers are always rendered with `FontWeight.w100` (ultra-thin), regardless of what style the user sets on `GptMarkdown`. This makes the numbers look visually inconsistent with the list content and ignores any custom font weight, font family, or other style properties the user expects to apply.

Reported in #105.

## Root Cause

In `OrderedList.build` inside `lib/markdown_component.dart`, the number label style was hardcoded:

```dart
// Before
style: (config.style ?? const TextStyle()).copyWith(
  fontWeight: FontWeight.w100,  // always ultra-thin, overrides user setting
),
```

`copyWith(fontWeight: FontWeight.w100)` forces the number to be ultra-thin no matter what the user specified in their `GptMarkdown(style: ...)`.

## Fix

Remove the hardcoded override and pass `config.style` directly, so the number respects the user's style:

```dart
// After
style: config.style,
```

The number label now matches whatever style the surrounding text uses — consistent font weight, color, and family.

Closes #105