### PR TITLE
fix: apply link color and underline to all link text, including bold/italic inline content

### DIFF
--- a/lib/markdown_component.dart
+++ b/lib/markdown_component.dart
@@ -856,12 +856,15 @@ class ATagMd extends InlineMd {
       false,
     );
     var theme = GptMarkdownTheme.of(context);
+    final linkStyle = (config.style ?? const TextStyle()).copyWith(
+      color: theme.linkColor,
+      decorationColor: theme.linkColor,
+      decoration: TextDecoration.underline,
+    );
+    final linkConfig = config.copyWith(style: linkStyle);
     var linkTextSpan = TextSpan(
-      children: MarkdownComponent.generate(context, linkText, config, false),
-      style: config.style?.copyWith(
-        color: theme.linkColor,
-        decorationColor: theme.linkColor,
-      ),
+      children: MarkdownComponent.generate(context, linkText, linkConfig, false),
+      style: linkStyle,
     );
 
     // Use custom builder if provided


### PR DESCRIPTION
## Problem

Link text does not render with the configured link color or underline decoration, even when `GptMarkdownThemeData.linkColor` is set. If the link text contains any inline formatting (bold, italic, etc.), those inner spans use the base text color instead of the link color entirely.

Reported in #85.

## Root Cause

Two bugs in `ATagMd` inside `lib/markdown_component.dart`:

**1. Children generated with the wrong config**

```dart
// Before — children use config (original style, no link color)
children: MarkdownComponent.generate(context, linkText, config, false),
```

`TextSpan` children with explicit styles (e.g. bold text inside a link) override their parent span's style. Putting the link color only on the parent `TextSpan.style` does nothing for children that set their own color.

**2. Missing underline + null-unsafe style**

```dart
// Before — underline never set; returns null when config.style is null
style: config.style?.copyWith(
  color: theme.linkColor,
  decorationColor: theme.linkColor,
  // decoration: TextDecoration.underline   ← missing!
),
```

## Fix

Build a `linkStyle` and a `linkConfig` that carry the link color and underline, then generate children using `linkConfig` so every span — plain text, bold, italic — inherits the link color:

```dart
// After
final linkStyle = (config.style ?? const TextStyle()).copyWith(
  color: theme.linkColor,
  decorationColor: theme.linkColor,
  decoration: TextDecoration.underline,
);
final linkConfig = config.copyWith(style: linkStyle);
var linkTextSpan = TextSpan(
  children: MarkdownComponent.generate(context, linkText, linkConfig, false),
  style: linkStyle,
);
```

Now `[**bold link**](url)` renders bold AND blue AND underlined, as expected.

Closes #85