### PR TITLE
feat: add selectable parameter for text selection on desktop/web

### DIFF
--- a/lib/gpt_markdown.dart
+++ b/lib/gpt_markdown.dart
@@ -44,6 +44,7 @@ class GptMarkdown extends StatelessWidget {
     this.components,
     this.inlineComponents,
     this.useDollarSignsForLatex = false,
+    this.selectable = false,
   });
 
   /// The direction of the text.
@@ -100,6 +101,14 @@ class GptMarkdown extends StatelessWidget {
 
   /// Whether to use dollar signs for LaTeX.
   final bool useDollarSignsForLatex;
+
+  /// Whether to make the rendered content selectable.
+  ///
+  /// When `true`, the markdown output is wrapped in a [SelectionArea] so users
+  /// can highlight and copy text on any platform.
+  /// Non-text content such as code blocks participates in selection via the
+  /// built-in [SelectableAdapter] widget.
+  final bool selectable;
 
   /// The table builder.
   final TableBuilder? tableBuilder;
@@ -181,7 +190,7 @@ class GptMarkdown extends StatelessWidget {
       }
     }
     // tex = _removeExtraLinesInsideBlockLatex(tex);
-    return ClipRRect(
+    final Widget content = ClipRRect(
       child: MdWidget(
         context,
         tex,
@@ -210,5 +219,9 @@ class GptMarkdown extends StatelessWidget {
         ),
       ),
     );
+    if (selectable) {
+      return SelectionArea(child: content);
+    }
+    return content;
   }
 }


### PR DESCRIPTION
## Problem

There is no way to make `GptMarkdown` output selectable. Users on desktop and web need to be able to highlight and copy the rendered markdown text, but the current widget uses `Text.rich` which is not selectable by default.

## Solution

Add a `selectable` boolean parameter (default: `false`) to `GptMarkdown`. When `true`, the output is wrapped in Flutter's `SelectionArea` widget.

```dart
GptMarkdown(
  '**Hello**, world! Visit [pub.dev](https://pub.dev)',
  selectable: true,
)
```

## How it works

- `SelectionArea` makes all `Text` and `Text.rich` descendants selectable automatically — no changes needed to any inner widget.
- Code blocks and other non-text content already use `SelectableAdapter`, which registers itself with the nearest `SelectionContainer` (provided by `SelectionArea`) and participates in drag-to-select and copy. This infrastructure was already in place.
- When `selectable: false` (the default) the output is identical to today — zero overhead.

## Changed files

- `lib/gpt_markdown.dart` — adds `selectable` constructor param and `SelectionArea` wrap in `build()`

Closes #118
