### PR TITLE
fix: link colour and hover colour now apply to all inline spans

### DIFF
--- a/lib/custom_widgets/link_button.dart
+++ b/lib/custom_widgets/link_button.dart
@@ -2,19 +2,27 @@ import 'package:flutter/material.dart';
 
 import 'markdown_config.dart';
 
-/// A custom button widget that displays a link with customizable colors and styles.
+/// A builder that creates a styled [InlineSpan] for the given link [color].
 ///
-/// The [LinkButton] widget is used to create a button that displays a link in the UI.
-/// It takes a [text] parameter which is the text of the link,
-/// a [config] parameter which is the configuration for the link,
-/// a [color] parameter to set the color of the link,
+/// [LinkButton] calls this on every rebuild so the span is always coloured
+/// with the current hover state — normal [LinkButton.color] or
+/// [LinkButton.hoverColor].
+typedef LinkSpanBuilder = InlineSpan Function(Color color);
 
+/// A custom button widget that displays a link with customisable colours.
 class LinkButton extends StatefulWidget {
-  /// The text of the link.
+  /// The raw link text (used only as fallback when neither [child] nor
+  /// [spanBuilder] is provided).
   final String text;
 
-  /// The child of the link.
+  /// A pre-built child widget (used by [linkBuilder] custom rendering).
   final Widget? child;
+
+  /// Builds a colour-aware [InlineSpan] for the link text.
+  ///
+  /// Called with the current colour on every rebuild so hover transitions
+  /// update all inline spans, including bold and italic content inside links.
+  final LinkSpanBuilder? spanBuilder;
 
   /// The callback function to be called when the link is pressed.
   final VoidCallback? onPressed;
@@ -28,10 +36,10 @@ class LinkButton extends StatefulWidget {
   /// The configuration for the link.
   final GptMarkdownConfig config;
 
-  /// The color of the link.
+  /// The colour used for the link in its default (non-hover) state.
   final Color color;
 
-  /// The color of the link when hovering.
+  /// The colour used for the link when the cursor is hovering over it.
   final Color hoverColor;
 
   const LinkButton({
@@ -44,6 +52,7 @@ class LinkButton extends StatefulWidget {
     this.textStyle,
     this.url,
     this.child,
+    this.spanBuilder,
   });
 
   @override
@@ -55,11 +64,25 @@ class _LinkButtonState extends State<LinkButton> {
 
   @override
   Widget build(BuildContext context) {
-    var style = (widget.config.style ?? const TextStyle()).copyWith(
-      color: _isHovering ? widget.hoverColor : widget.color,
-      decoration: TextDecoration.underline,
-      decorationColor: _isHovering ? widget.hoverColor : widget.color,
-    );
+    final currentColor = _isHovering ? widget.hoverColor : widget.color;
+
+    Widget content;
+    if (widget.child != null) {
+      // Custom linkBuilder — use the pre-built widget as-is.
+      content = widget.child!;
+    } else if (widget.spanBuilder != null) {
+      // Default path — rebuild the span with the current hover colour.
+      content = widget.config.getRich(widget.spanBuilder!(currentColor));
+    } else {
+      // Fallback plain text path (no inline formatting in link text).
+      final style = (widget.config.style ?? const TextStyle()).copyWith(
+        color: currentColor,
+        decoration: TextDecoration.underline,
+        decorationColor: currentColor,
+      );
+      content = widget.config.getRich(TextSpan(text: widget.text, style: style));
+    }
+
     return MouseRegion(
       cursor: SystemMouseCursors.click,
       onEnter: (_) => _handleHover(true),
@@ -69,9 +92,7 @@ class _LinkButtonState extends State<LinkButton> {
         onTapUp: (_) => _handlePress(false),
         onTapCancel: () => _handlePress(false),
         onTap: widget.onPressed,
-        child:
-            widget.child ??
-            widget.config.getRich(TextSpan(text: widget.text, style: style)),
+        child: content,
       ),
     );
   }

--- a/lib/markdown_component.dart
+++ b/lib/markdown_component.dart
@@ -857,25 +857,21 @@ class ATagMd extends InlineMd {
       false,
     );
     var theme = GptMarkdownTheme.of(context);
-    final linkStyle = (config.style ?? const TextStyle()).copyWith(
-      color: theme.linkColor,
-      decorationColor: theme.linkColor,
-      decoration: TextDecoration.underline,
-    );
-    final linkConfig = config.copyWith(style: linkStyle);
-    var linkTextSpan = TextSpan(
-      children: MarkdownComponent.generate(
-        context,
-        linkText,
-        linkConfig,
-        false,
-      ),
-      style: linkStyle,
-    );
 
     // Use custom builder if provided
     WidgetSpan? child;
     if (builder != null) {
+      // Build a styled span to hand off to the custom linkBuilder.
+      final linkStyle = (config.style ?? const TextStyle()).copyWith(
+        color: theme.linkColor,
+        decorationColor: theme.linkColor,
+        decoration: TextDecoration.underline,
+      );
+      final linkConfig = config.copyWith(style: linkStyle);
+      final linkTextSpan = TextSpan(
+        children: MarkdownComponent.generate(context, linkText, linkConfig, false),
+        style: linkStyle,
+      );
       child = WidgetSpan(
         baseline: TextBaseline.alphabetic,
         alignment: PlaceholderAlignment.baseline,
@@ -891,7 +887,8 @@ class ATagMd extends InlineMd {
       );
     }
 
-    // Default rendering
+    // Default rendering — LinkButton rebuilds the span on every hover change
+    // so bold/italic text inside a link also picks up the hover colour.
     child ??= WidgetSpan(
       alignment: PlaceholderAlignment.baseline,
       baseline: TextBaseline.alphabetic,
@@ -903,7 +900,22 @@ class ATagMd extends InlineMd {
         },
         text: linkText,
         config: config,
-        child: config.getRich(linkTextSpan),
+        spanBuilder: (color) {
+          final spanStyle = (config.style ?? const TextStyle()).copyWith(
+            color: color,
+            decorationColor: color,
+            decoration: TextDecoration.underline,
+          );
+          return TextSpan(
+            children: MarkdownComponent.generate(
+              context,
+              linkText,
+              config.copyWith(style: spanStyle),
+              false,
+            ),
+            style: spanStyle,
+          );
+        },
       ),
     );
     var textSpan = TextSpan(children: [child, ...endingSpans]);


### PR DESCRIPTION
Supersedes #134 (closed when branch was recreated to resolve merge conflict).

## Changes

### `lib/custom_widgets/link_button.dart`
- Adds `LinkSpanBuilder` typedef: `InlineSpan Function(Color color)`
- Adds optional `spanBuilder` parameter to `LinkButton`
- On hover, `spanBuilder` is called with the current colour so **all** inline spans (bold, italic, code) inside a link update their colour — not just plain text
- Falls back to plain-text rendering if neither `child` nor `spanBuilder` is provided

### `lib/markdown_component.dart` (`ATagMd`)
- Default link rendering now passes `spanBuilder:` instead of a pre-built `child:` widget
- The closure rebuilds `MarkdownComponent.generate(...)` with the hover colour on every rebuild, so rich link text (e.g. `**bold link**`) correctly transitions colour on hover
- Custom `linkBuilder` path is unchanged — still receives a pre-styled `TextSpan`