### PR TITLE
feat: YAML frontmatter support (agent.md / SKILL.md)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.1
+
+* Frontmatter is now **rendered as a table by default**. When a document has frontmatter and no `frontmatterBuilder` is supplied, `GptMarkdown` shows the parsed metadata as a `key | value` table (the new public `GptMarkdownFrontmatterTable` widget) above the body — similar to how editors display `agent.md` / `SKILL.md` metadata. Previously it was hidden unless a builder was provided.
+* To hide the frontmatter, return `const SizedBox.shrink()` from `frontmatterBuilder`.
+* Updated the example app (`main.dart` now relies on the default table) and docs accordingly.
+
 ## 1.2.0
 
 * Added **YAML frontmatter** support. A document beginning with a `---` fenced block is now parsed as frontmatter and removed from the rendered body instead of being rendered as a stray horizontal rule plus raw text.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.2.0
+
+* Added **YAML frontmatter** support. A document beginning with a `---` fenced block is now parsed as frontmatter and removed from the rendered body instead of being rendered as a stray horizontal rule plus raw text.
+* Added `GptMarkdownFrontmatter`, a dependency-free parser for the common YAML subset used in frontmatter (scalars with `int`/`double`/`bool`/`null` coercion, quoted strings, nested mappings, block & flow sequences, flow mappings, block scalars `|`/`>`, and `#` comments). Use `GptMarkdownFrontmatter.parse` / `GptMarkdownFrontmatter.split` to read metadata without rendering.
+* Added the `frontmatterBuilder` parameter to `GptMarkdown` (and the `FrontmatterBuilder` typedef) to render the parsed frontmatter above the body. When omitted, frontmatter is hidden.
+* Updated the example app and playground with an `agent.md`-style sample, a reusable `FrontmatterCard` widget, and a standalone `example/agent.md`.
+* Documented frontmatter in the README and added tests for the parser and widget integration.
+
 ## 1.1.7
 
 * Added/updated the interactive playground and pub.dev example flow, with `playground.dart` as a dedicated playground entry and improved demo content for links, lists, blockquotes, tables, and LaTeX.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2
+
+* Fixed the frontmatter table so the colored key cells fill the full row height. Previously, when a value (e.g. a long `description`) wrapped onto several lines, the key cell's background only covered the text line instead of the whole cell.
+
 ## 1.2.1
 
 * Frontmatter is now **rendered as a table by default**. When a document has frontmatter and no `frontmatterBuilder` is supplied, `GptMarkdown` shows the parsed metadata as a `key | value` table (the new public `GptMarkdownFrontmatterTable` widget) above the body — similar to how editors display `agent.md` / `SKILL.md` metadata. Previously it was hidden unless a builder was provided.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A Flutter package for rendering rich Markdown and LaTeX in your app — built fo
 | 📱 Selectable | ✅ |
 | 🧩 Custom components | ✅ |  |
 | 📎 Underline | ✅ |  |
+| 📑 YAML Frontmatter | ✅ |  |
 
 ## ✨ Key Features
 
@@ -123,6 +124,77 @@ Render a wide variety of content with full Markdown and LaTeX support, including
 [] Unchecked checkbox
 [x] Checked checkbox
 ```
+
+- YAML frontmatter (e.g. `agent.md` / `SKILL.md` files)
+
+```
+---
+name: code-reviewer
+description: Reviews diffs for bugs.
+tags:
+  - review
+  - quality
+---
+```
+
+---
+
+## 📑 Frontmatter
+
+A document that begins with a `---` fenced block is treated as having **YAML
+frontmatter** — the metadata convention used by static site generators and AI
+agent files such as `agent.md` and `SKILL.md`.
+
+gpt_markdown parses the block, removes it from the rendered body and hands the
+result to your `frontmatterBuilder`. If you don't supply a builder, the
+frontmatter is simply hidden (it is never rendered as broken markdown).
+
+```dart
+GptMarkdown(
+  r'''
+---
+name: code-reviewer
+description: Reviews diffs for bugs and style issues.
+tags:
+  - review
+  - quality
+tools: [Read, Grep, Bash]
+---
+
+# Code Reviewer
+
+Body content here...
+''',
+  frontmatterBuilder: (context, frontmatter) {
+    return Card(
+      child: ListTile(
+        title: Text(frontmatter.string('name') ?? ''),
+        subtitle: Text(frontmatter.string('description') ?? ''),
+        trailing: Text(frontmatter.stringList('tags').join(', ')),
+      ),
+    );
+  },
+)
+```
+
+You can also parse frontmatter on its own — handy when you need the metadata
+outside of rendering:
+
+```dart
+final fm = GptMarkdownFrontmatter.parse(markdown);
+print(fm?['name']);                 // 'code-reviewer'
+print(fm?.stringList('tags'));      // ['review', 'quality']
+
+// Or split it from the body explicitly:
+final result = GptMarkdownFrontmatter.split(markdown);
+print(result.frontmatter?['name']); // 'code-reviewer'
+print(result.body);                 // markdown without the frontmatter
+```
+
+The parser supports the common subset of YAML used in frontmatter: scalars
+(with `int` / `double` / `bool` / `null` coercion), quoted strings, nested
+mappings, block and flow sequences (`[a, b]`), flow mappings (`{x: 1}`), block
+scalars (`|` and `>`) and `#` comments.
 
 - Enable text selection on desktop and web:
 

--- a/README.md
+++ b/README.md
@@ -145,9 +145,10 @@ A document that begins with a `---` fenced block is treated as having **YAML
 frontmatter** — the metadata convention used by static site generators and AI
 agent files such as `agent.md` and `SKILL.md`.
 
-gpt_markdown parses the block, removes it from the rendered body and hands the
-result to your `frontmatterBuilder`. If you don't supply a builder, the
-frontmatter is simply hidden (it is never rendered as broken markdown).
+gpt_markdown parses the block and removes it from the rendered body. **By
+default it renders the frontmatter as a table** (a `GptMarkdownFrontmatterTable`)
+above the content — just like editors show `agent.md` / `SKILL.md` metadata — so
+it works out of the box:
 
 ```dart
 GptMarkdown(
@@ -155,16 +156,23 @@ GptMarkdown(
 ---
 name: code-reviewer
 description: Reviews diffs for bugs and style issues.
-tags:
-  - review
-  - quality
-tools: [Read, Grep, Bash]
+tools: Read, Grep, Bash
+model: sonnet
 ---
 
 # Code Reviewer
 
 Body content here...
 ''',
+)
+```
+
+Want a custom look? Pass a `frontmatterBuilder` (return `const
+SizedBox.shrink()` to hide the frontmatter entirely):
+
+```dart
+GptMarkdown(
+  agentMarkdown,
   frontmatterBuilder: (context, frontmatter) {
     return Card(
       child: ListTile(

--- a/example/agent.md
+++ b/example/agent.md
@@ -1,0 +1,36 @@
+---
+name: code-reviewer
+description: Reviews pull request diffs for correctness bugs and style issues.
+model: claude-opus-4-8
+version: 1.2.0
+tags:
+  - review
+  - quality
+  - automation
+tools: [Read, Grep, Bash]
+metadata:
+  author: gpt_markdown
+  category: engineering
+---
+
+# Code Reviewer
+
+You are a meticulous **code reviewer**. Given a diff, you:
+
+1. Flag correctness bugs first, with a short justification.
+2. Point out reuse and simplification opportunities.
+3. Keep style nits to a minimum and clearly labelled.
+
+> Everything above the first `# heading` is YAML *frontmatter* — metadata that
+> `gpt_markdown` parses out of the body and hands to your `frontmatterBuilder`.
+
+## Example
+
+```dart
+GptMarkdown(
+  agentMarkdown,
+  frontmatterBuilder: (context, frontmatter) {
+    return Text('Agent: ${frontmatter.string('name')}');
+  },
+)
+```

--- a/example/lib/frontmatter_card.dart
+++ b/example/lib/frontmatter_card.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+
+/// A small card that renders parsed [GptMarkdownFrontmatter] as document
+/// metadata — a title, description, tag chips and any remaining key/value
+/// pairs. Pass it to `GptMarkdown(frontmatterBuilder: ...)`.
+///
+/// ```dart
+/// GptMarkdown(
+///   agentMarkdown,
+///   frontmatterBuilder: (context, frontmatter) =>
+///       FrontmatterCard(frontmatter: frontmatter),
+/// )
+/// ```
+class FrontmatterCard extends StatelessWidget {
+  const FrontmatterCard({super.key, required this.frontmatter});
+
+  final GptMarkdownFrontmatter frontmatter;
+
+  // Keys that get special, prominent treatment.
+  static const _titleKeys = ['name', 'title'];
+  static const _descriptionKeys = ['description', 'summary'];
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+
+    final title = _firstOf(_titleKeys);
+    final description = _firstOf(_descriptionKeys);
+    final handledKeys = {..._titleKeys, ..._descriptionKeys};
+
+    // Everything else, in document order.
+    final rest = frontmatter.fields.entries
+        .where((e) => !handledKeys.contains(e.key))
+        .toList();
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 16),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest.withValues(alpha: 0.5),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: scheme.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.description_outlined, size: 18, color: scheme.primary),
+              const SizedBox(width: 8),
+              Text(
+                'Frontmatter',
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: scheme.primary,
+                  fontWeight: FontWeight.bold,
+                  letterSpacing: 0.5,
+                ),
+              ),
+            ],
+          ),
+          if (title != null) ...[
+            const SizedBox(height: 10),
+            Text(
+              title,
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+          if (description != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              description,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: scheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+          for (final entry in rest) ...[
+            const SizedBox(height: 10),
+            _Field(label: entry.key, value: entry.value),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String? _firstOf(List<String> keys) {
+    for (final key in keys) {
+      final value = frontmatter.string(key);
+      if (value != null && value.isNotEmpty) return value;
+    }
+    return null;
+  }
+}
+
+class _Field extends StatelessWidget {
+  const _Field({required this.label, required this.value});
+
+  final String label;
+  final dynamic value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final labelStyle = theme.textTheme.labelSmall?.copyWith(
+      color: scheme.onSurfaceVariant,
+      fontWeight: FontWeight.bold,
+      letterSpacing: 0.4,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label.toUpperCase(), style: labelStyle),
+        const SizedBox(height: 4),
+        if (value is List)
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              for (final item in value as List) _Chip(label: '$item'),
+            ],
+          )
+        else if (value is Map)
+          Text(
+            (value as Map).entries.map((e) => '${e.key}: ${e.value}').join(', '),
+            style: theme.textTheme.bodyMedium,
+          )
+        else
+          Text('$value', style: theme.textTheme.bodyMedium),
+      ],
+    );
+  }
+}
+
+class _Chip extends StatelessWidget {
+  const _Chip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: scheme.primary.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: scheme.primary.withValues(alpha: 0.3)),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: scheme.primary,
+          fontSize: 12,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 
-import 'frontmatter_card.dart';
-
 /// Minimal example for gpt_markdown — Markdown & LaTeX renderer for Flutter.
 ///
 /// For the full interactive playground visit https://gptmarkdown.com/playground
@@ -35,8 +33,8 @@ class App extends StatelessWidget {
 /// Sample content demonstrating the key features of gpt_markdown.
 ///
 /// The leading `---` block is YAML frontmatter (as found in `agent.md` /
-/// `SKILL.md` files). gpt_markdown parses it out of the body and passes it to
-/// the `frontmatterBuilder` below instead of rendering it as markdown.
+/// `SKILL.md` files). gpt_markdown parses it out of the body and, by default,
+/// renders it as a table above the content.
 const _markdown = r'''
 ---
 name: GPT Markdown
@@ -120,11 +118,11 @@ class ExamplePage extends StatelessWidget {
       appBar: AppBar(title: const Text('gpt_markdown')),
       body: SingleChildScrollView(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+        // No frontmatterBuilder is passed, so the leading YAML frontmatter is
+        // rendered with the built-in GptMarkdownFrontmatterTable.
         child: GptMarkdown(
           _markdown,
           onLinkTap: (url, title) => debugPrint('Link tapped: $url'),
-          frontmatterBuilder: (context, frontmatter) =>
-              FrontmatterCard(frontmatter: frontmatter),
         ),
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 
+import 'frontmatter_card.dart';
+
 /// Minimal example for gpt_markdown — Markdown & LaTeX renderer for Flutter.
 ///
 /// For the full interactive playground visit https://gptmarkdown.com/playground
@@ -31,7 +33,21 @@ class App extends StatelessWidget {
 }
 
 /// Sample content demonstrating the key features of gpt_markdown.
+///
+/// The leading `---` block is YAML frontmatter (as found in `agent.md` /
+/// `SKILL.md` files). gpt_markdown parses it out of the body and passes it to
+/// the `frontmatterBuilder` below instead of rendering it as markdown.
 const _markdown = r'''
+---
+name: GPT Markdown
+description: Markdown & LaTeX renderer for Flutter, tuned for AI output.
+version: 1.2.0
+tags:
+  - markdown
+  - latex
+  - flutter
+---
+
 # GPT Markdown
 
 **Bold**, *italic*, ~~strikethrough~~, `inline code`, and <u>underline</u>.
@@ -107,6 +123,8 @@ class ExamplePage extends StatelessWidget {
         child: GptMarkdown(
           _markdown,
           onLinkTap: (url, title) => debugPrint('Link tapped: $url'),
+          frontmatterBuilder: (context, frontmatter) =>
+              FrontmatterCard(frontmatter: frontmatter),
         ),
       ),
     );

--- a/example/lib/playground.dart
+++ b/example/lib/playground.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 import 'package:flutter_math_fork/flutter_math.dart';
+
+import 'frontmatter_card.dart';
 // import 'package:gpt_markdown/custom_widgets/selectable_adapter.dart';
 
 void main() {
@@ -138,6 +140,38 @@ def reverse_list(head: ListNode) -> ListNode:
 | Italic | `*text*` | *text* |
 | Code | `` `code` `` | `code` |
 | Strike | `~~text~~` | ~~text~~ |
+''',
+  'Agent.md': r'''---
+name: code-reviewer
+description: Reviews pull request diffs for correctness bugs and style issues.
+model: claude-opus-4-8
+version: 1.2.0
+tags:
+  - review
+  - quality
+  - automation
+tools: [Read, Grep, Bash]
+---
+
+# Code Reviewer
+
+You are a meticulous **code reviewer**. Given a diff, you:
+
+1. Flag correctness bugs first, with a short justification.
+2. Point out reuse and simplification opportunities.
+3. Keep style nits to a minimum and clearly labelled.
+
+> Everything above the first heading is YAML *frontmatter*. gpt_markdown parses
+> it out of the body and hands it to your `frontmatterBuilder`.
+
+```dart
+GptMarkdown(
+  agentMarkdown,
+  frontmatterBuilder: (context, frontmatter) {
+    return Text('Agent: ${frontmatter.string('name')}');
+  },
+)
+```
 ''',
 };
 
@@ -451,6 +485,8 @@ class _PlaygroundPageState extends State<PlaygroundPage> {
                     _controller.text,
                     textDirection: _direction,
                     useDollarSignsForLatex: _useDollarLatex,
+                    frontmatterBuilder: (context, frontmatter) =>
+                        FrontmatterCard(frontmatter: frontmatter),
                     latexBuilder: (context, tex, textStyle, inline) {
                       final widget = Math.tex(
                         tex,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -105,7 +105,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.2.1"
   http:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -105,7 +105,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.1"
+    version: "1.2.2"
   http:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -105,7 +105,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.7"
+    version: "1.2.0"
   http:
     dependency: transitive
     description:

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,30 +1,23 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
+// Smoke test for the gpt_markdown example app.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
 
 import 'package:example/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('example app renders markdown and its frontmatter', (
+    tester,
+  ) async {
     await tester.pumpWidget(const App());
+    await tester.pumpAndSettle();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    // The markdown body is rendered.
+    expect(find.byType(GptMarkdown), findsOneWidget);
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // The leading YAML frontmatter is parsed and shown via the
+    // FrontmatterCard rather than rendered as raw markdown.
+    expect(find.text('Frontmatter'), findsOneWidget);
+    expect(find.text('GPT Markdown'), findsWidgets);
   });
 }

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -15,9 +15,10 @@ void main() {
     // The markdown body is rendered.
     expect(find.byType(GptMarkdown), findsOneWidget);
 
-    // The leading YAML frontmatter is parsed and shown via the
-    // FrontmatterCard rather than rendered as raw markdown.
-    expect(find.text('Frontmatter'), findsOneWidget);
-    expect(find.text('GPT Markdown'), findsWidgets);
+    // The leading YAML frontmatter is parsed and shown via the built-in
+    // frontmatter table rather than rendered as raw markdown.
+    expect(find.byType(GptMarkdownFrontmatterTable), findsOneWidget);
+    expect(find.text('name'), findsOneWidget);
+    expect(find.textContaining('GPT Markdown'), findsWidgets);
   });
 }

--- a/lib/custom_widgets/markdown_config.dart
+++ b/lib/custom_widgets/markdown_config.dart
@@ -66,7 +66,8 @@ typedef HighlightBuilder =
 ///
 /// When the markdown begins with a `---` fenced frontmatter block it is parsed
 /// and removed from the rendered body. If a builder is supplied, its output is
-/// rendered above the body; otherwise the frontmatter is hidden.
+/// rendered above the body; otherwise a default [GptMarkdownFrontmatterTable]
+/// is shown.
 typedef FrontmatterBuilder =
     Widget Function(
       BuildContext context,

--- a/lib/custom_widgets/markdown_config.dart
+++ b/lib/custom_widgets/markdown_config.dart
@@ -62,6 +62,17 @@ typedef TableBuilder =
 typedef HighlightBuilder =
     Widget Function(BuildContext context, String text, TextStyle style);
 
+/// A builder function for the document [GptMarkdownFrontmatter].
+///
+/// When the markdown begins with a `---` fenced frontmatter block it is parsed
+/// and removed from the rendered body. If a builder is supplied, its output is
+/// rendered above the body; otherwise the frontmatter is hidden.
+typedef FrontmatterBuilder =
+    Widget Function(
+      BuildContext context,
+      GptMarkdownFrontmatter frontmatter,
+    );
+
 /// A builder function for the image.
 ///
 /// [width] and [height] come from the image alt text when parsed as `WxH`

--- a/lib/frontmatter.dart
+++ b/lib/frontmatter.dart
@@ -391,6 +391,92 @@ class GptMarkdownFrontmatter {
   }
 }
 
+/// The default renderer for [GptMarkdownFrontmatter] — a bordered two-column
+/// table of `key | value` rows, similar to how editors such as VS Code display
+/// the frontmatter of `agent.md` / `SKILL.md` files.
+///
+/// [GptMarkdown] uses this automatically whenever a document has frontmatter
+/// and no custom `frontmatterBuilder` is supplied. You can also use it directly
+/// from a `frontmatterBuilder`:
+///
+/// ```dart
+/// GptMarkdown(
+///   agentMarkdown,
+///   frontmatterBuilder: (context, frontmatter) =>
+///       GptMarkdownFrontmatterTable(frontmatter: frontmatter),
+/// )
+/// ```
+class GptMarkdownFrontmatterTable extends StatelessWidget {
+  const GptMarkdownFrontmatterTable({
+    super.key,
+    required this.frontmatter,
+    this.style,
+  });
+
+  /// The parsed frontmatter to display.
+  final GptMarkdownFrontmatter frontmatter;
+
+  /// Base text style for the table cells. Keys are rendered bold.
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = frontmatter.fields.entries.toList();
+    if (entries.isEmpty) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    final gptTheme = GptMarkdownTheme.of(context);
+    final baseStyle = style ?? DefaultTextStyle.of(context).style;
+    final keyStyle = baseStyle.copyWith(fontWeight: FontWeight.bold);
+    final borderColor = gptTheme.hrLineColor;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Table(
+        border: TableBorder.all(color: borderColor, width: 1),
+        columnWidths: const {
+          0: IntrinsicColumnWidth(),
+          1: FlexColumnWidth(),
+        },
+        defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+        children: [
+          for (final entry in entries)
+            TableRow(
+              children: [
+                _cell(
+                  entry.key,
+                  keyStyle,
+                  background: theme.colorScheme.surfaceContainerHighest
+                      .withValues(alpha: 0.4),
+                ),
+                _cell(_stringify(entry.value), baseStyle),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _cell(String text, TextStyle textStyle, {Color? background}) {
+    return Container(
+      color: background,
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      child: Text(text, style: textStyle),
+    );
+  }
+
+  static String _stringify(dynamic value) {
+    if (value == null) return '';
+    if (value is List) return value.map(_stringify).join(', ');
+    if (value is Map) {
+      return value.entries
+          .map((e) => '${e.key}: ${_stringify(e.value)}')
+          .join(', ');
+    }
+    return value.toString();
+  }
+}
+
 /// A significant frontmatter line: its indentation and trimmed content.
 class _FmLine {
   const _FmLine(this.indent, this.content);

--- a/lib/frontmatter.dart
+++ b/lib/frontmatter.dart
@@ -458,11 +458,22 @@ class GptMarkdownFrontmatterTable extends StatelessWidget {
   }
 
   Widget _cell(String text, TextStyle textStyle, {Color? background}) {
-    return Container(
+    final content = Container(
       color: background,
+      alignment: background != null ? Alignment.centerLeft : null,
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       child: Text(text, style: textStyle),
     );
+    // Colored (key) cells must stretch to the full row height so the
+    // background fills the whole cell — not just the text line when the value
+    // in the same row wraps onto several lines.
+    if (background != null) {
+      return TableCell(
+        verticalAlignment: TableCellVerticalAlignment.fill,
+        child: content,
+      );
+    }
+    return content;
   }
 
   static String _stringify(dynamic value) {

--- a/lib/frontmatter.dart
+++ b/lib/frontmatter.dart
@@ -1,0 +1,515 @@
+part of 'gpt_markdown.dart';
+
+/// The YAML frontmatter block found at the very top of a markdown document.
+///
+/// Frontmatter is a metadata block fenced by `---` lines at the start of a
+/// document, widely used by static site generators and, more recently, by AI
+/// agent definition files such as `agent.md` and `SKILL.md`:
+///
+/// ```markdown
+/// ---
+/// name: code-reviewer
+/// description: Reviews diffs for bugs and style issues.
+/// tags:
+///   - review
+///   - quality
+/// ---
+///
+/// # Code Reviewer
+/// ...
+/// ```
+///
+/// [GptMarkdown] detects this block, removes it from the rendered body and —
+/// when a `frontmatterBuilder` is supplied — hands the parsed result to that
+/// builder so it can be displayed however you like.
+///
+/// The bundled parser understands the common subset of YAML used in
+/// frontmatter: scalars (with `int`/`double`/`bool`/`null` coercion), quoted
+/// strings, nested mappings, block and flow sequences, flow mappings, block
+/// scalars (`|` and `>`) and `#` comments. It is intentionally dependency-free
+/// and does not aim to be a complete YAML implementation.
+class GptMarkdownFrontmatter {
+  /// Creates a frontmatter holding the [raw] text and its parsed [fields].
+  const GptMarkdownFrontmatter({required this.raw, required this.fields});
+
+  /// The raw text found between the opening and closing `---` fences.
+  final String raw;
+
+  /// The parsed key/value pairs.
+  ///
+  /// Values may be a [String], [int], [double], [bool], `null`, a [List] or a
+  /// nested [Map].
+  final Map<String, dynamic> fields;
+
+  /// Whether no fields were parsed.
+  bool get isEmpty => fields.isEmpty;
+
+  /// Whether at least one field was parsed.
+  bool get isNotEmpty => fields.isNotEmpty;
+
+  /// The parsed keys, in document order.
+  Iterable<String> get keys => fields.keys;
+
+  /// Returns the raw value for [key], or `null` when absent.
+  dynamic operator [](String key) => fields[key];
+
+  /// Whether [key] is present.
+  bool containsKey(String key) => fields.containsKey(key);
+
+  /// Returns [key] coerced to a [String], or `null` when absent.
+  String? string(String key) {
+    final value = fields[key];
+    return value?.toString();
+  }
+
+  /// Returns [key] as a list of strings.
+  ///
+  /// A scalar value becomes a single-element list and a missing key returns an
+  /// empty list, so callers never have to null-check.
+  List<String> stringList(String key) {
+    final value = fields[key];
+    if (value == null) return const [];
+    if (value is List) {
+      return value.map((e) => e.toString()).toList();
+    }
+    return [value.toString()];
+  }
+
+  /// Parses the frontmatter at the start of [source].
+  ///
+  /// Returns `null` when [source] does not begin with a `---` frontmatter
+  /// block. Use [split] when you also need the markdown body.
+  static GptMarkdownFrontmatter? parse(String source) => split(source).frontmatter;
+
+  /// Splits [source] into its leading frontmatter (if any) and markdown body.
+  ///
+  /// When [source] does not start with a frontmatter block — or starts with a
+  /// `---` block that yields no fields (for example two adjacent horizontal
+  /// rules) — the returned `frontmatter` is `null` and `body` is [source]
+  /// unchanged.
+  static ({GptMarkdownFrontmatter? frontmatter, String body}) split(
+    String source,
+  ) {
+    var text = source.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+    // Drop a leading byte order mark, if present.
+    if (text.startsWith('﻿')) {
+      text = text.substring(1);
+    }
+    // Allow blank lines / spaces before the opening fence.
+    final lead = RegExp(r'^[ \t\n]*').firstMatch(text)?.group(0) ?? '';
+    final candidate = text.substring(lead.length);
+    if (!candidate.startsWith('---')) {
+      return (frontmatter: null, body: source);
+    }
+    final lines = candidate.split('\n');
+    // The opening line must be exactly '---' (trailing spaces allowed).
+    if (lines.first.trimRight() != '---') {
+      return (frontmatter: null, body: source);
+    }
+    // Find the closing fence ('---' or '...').
+    int? closeIndex;
+    for (var i = 1; i < lines.length; i++) {
+      final trimmed = lines[i].trimRight();
+      if (trimmed == '---' || trimmed == '...') {
+        closeIndex = i;
+        break;
+      }
+    }
+    if (closeIndex == null) {
+      // No closing fence — not frontmatter, leave the document untouched.
+      return (frontmatter: null, body: source);
+    }
+    final raw = lines.sublist(1, closeIndex).join('\n');
+    final fields = _parse(raw);
+    // Only treat the block as frontmatter when it actually yields data. This
+    // keeps things like `---\n\n---` (two adjacent horizontal rules) rendering
+    // as markdown rather than being swallowed as an empty frontmatter block.
+    if (fields.isEmpty) {
+      return (frontmatter: null, body: source);
+    }
+    final body = lines.sublist(closeIndex + 1).join('\n');
+    return (
+      frontmatter: GptMarkdownFrontmatter(raw: raw, fields: fields),
+      body: body,
+    );
+  }
+
+  @override
+  String toString() => 'GptMarkdownFrontmatter($fields)';
+
+  // ---------------------------------------------------------------------------
+  // Parsing internals
+  // ---------------------------------------------------------------------------
+
+  static Map<String, dynamic> _parse(String raw) {
+    final lines = _toLines(raw);
+    if (lines.isEmpty) return <String, dynamic>{};
+    return _FrontmatterParser(lines).parse();
+  }
+
+  /// Splits [raw] into significant lines, dropping blank and comment lines and
+  /// recording each line's indentation (tabs count as two spaces).
+  static List<_FmLine> _toLines(String raw) {
+    final result = <_FmLine>[];
+    for (final original in raw.split('\n')) {
+      final line = original.replaceAll('\t', '  ');
+      final trimmedLeft = line.trimLeft();
+      if (trimmedLeft.isEmpty) continue; // blank line
+      if (trimmedLeft.startsWith('#')) continue; // comment line
+      final indent = line.length - trimmedLeft.length;
+      result.add(_FmLine(indent, trimmedLeft.trimRight()));
+    }
+    return result;
+  }
+
+  /// Splits a `key: value` line at the first top-level `:` that is followed by
+  /// whitespace or end of line, honouring quotes and flow collections.
+  ///
+  /// Returns `[key, value]` (the value keeps its leading space) or `null` when
+  /// the line is not a key/value pair.
+  static List<String>? _splitKeyValue(String s) {
+    var inSingle = false;
+    var inDouble = false;
+    var depth = 0;
+    for (var i = 0; i < s.length; i++) {
+      final c = s[i];
+      if (c == "'" && !inDouble) {
+        inSingle = !inSingle;
+      } else if (c == '"' && !inSingle) {
+        inDouble = !inDouble;
+      } else if (!inSingle && !inDouble) {
+        if (c == '[' || c == '{') {
+          depth++;
+        } else if (c == ']' || c == '}') {
+          if (depth > 0) depth--;
+        } else if (c == ':' && depth == 0) {
+          if (i + 1 >= s.length) {
+            return [s.substring(0, i), ''];
+          }
+          final next = s[i + 1];
+          if (next == ' ' || next == '\t') {
+            return [s.substring(0, i), s.substring(i + 1)];
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  static String _parseKey(String raw) {
+    final key = raw.trim();
+    if (key.length >= 2) {
+      final first = key[0];
+      final last = key[key.length - 1];
+      if ((first == '"' && last == '"') || (first == "'" && last == "'")) {
+        return key.substring(1, key.length - 1);
+      }
+    }
+    return key;
+  }
+
+  /// Converts a scalar value into a typed Dart value.
+  static dynamic _parseScalar(String raw) {
+    var s = raw.trim();
+    if (s.isEmpty) return null;
+
+    // Flow collections.
+    if (s.startsWith('[') && s.endsWith(']')) {
+      return _parseFlowList(s.substring(1, s.length - 1));
+    }
+    if (s.startsWith('{') && s.endsWith('}')) {
+      return _parseFlowMap(s.substring(1, s.length - 1));
+    }
+
+    // Quoted strings.
+    if (s.length >= 2 && s.startsWith('"') && s.endsWith('"')) {
+      return _unescapeDouble(s.substring(1, s.length - 1));
+    }
+    if (s.length >= 2 && s.startsWith("'") && s.endsWith("'")) {
+      return s.substring(1, s.length - 1).replaceAll("''", "'");
+    }
+
+    // Strip a trailing inline comment (" #...").
+    final commentIndex = _inlineCommentIndex(s);
+    if (commentIndex != -1) {
+      s = s.substring(0, commentIndex).trimRight();
+    }
+    if (s.isEmpty) return null;
+
+    // Null and booleans.
+    if (s == '~') return null;
+    switch (s.toLowerCase()) {
+      case 'null':
+        return null;
+      case 'true':
+        return true;
+      case 'false':
+        return false;
+    }
+
+    // Numbers.
+    final asInt = int.tryParse(s);
+    if (asInt != null) return asInt;
+    final asDouble = double.tryParse(s);
+    if (asDouble != null && !s.contains(RegExp(r'[^0-9eE+.\-]'))) {
+      return asDouble;
+    }
+
+    return s;
+  }
+
+  static List<dynamic> _parseFlowList(String inner) {
+    return _splitFlow(inner).map<dynamic>(_parseScalar).toList();
+  }
+
+  static Map<String, dynamic> _parseFlowMap(String inner) {
+    final map = <String, dynamic>{};
+    for (final part in _splitFlow(inner)) {
+      final p = part.trim();
+      if (p.isEmpty) continue;
+      final colon = _topLevelColon(p);
+      if (colon == -1) {
+        map[_parseKey(p)] = null;
+        continue;
+      }
+      final key = _parseKey(p.substring(0, colon));
+      final value = p.substring(colon + 1).trim();
+      map[key] = value.isEmpty ? null : _parseScalar(value);
+    }
+    return map;
+  }
+
+  /// Splits a flow collection body on top-level commas, honouring nested
+  /// brackets/braces and quotes.
+  static List<String> _splitFlow(String inner) {
+    final result = <String>[];
+    final buffer = StringBuffer();
+    var depth = 0;
+    var inSingle = false;
+    var inDouble = false;
+    for (var i = 0; i < inner.length; i++) {
+      final c = inner[i];
+      if (c == "'" && !inDouble) {
+        inSingle = !inSingle;
+      } else if (c == '"' && !inSingle) {
+        inDouble = !inDouble;
+      } else if (!inSingle && !inDouble) {
+        if (c == '[' || c == '{') {
+          depth++;
+        } else if (c == ']' || c == '}') {
+          if (depth > 0) depth--;
+        } else if (c == ',' && depth == 0) {
+          result.add(buffer.toString());
+          buffer.clear();
+          continue;
+        }
+      }
+      buffer.write(c);
+    }
+    if (buffer.toString().trim().isNotEmpty) {
+      result.add(buffer.toString());
+    }
+    return result;
+  }
+
+  static int _topLevelColon(String s) {
+    var inSingle = false;
+    var inDouble = false;
+    var depth = 0;
+    for (var i = 0; i < s.length; i++) {
+      final c = s[i];
+      if (c == "'" && !inDouble) {
+        inSingle = !inSingle;
+      } else if (c == '"' && !inSingle) {
+        inDouble = !inDouble;
+      } else if (!inSingle && !inDouble) {
+        if (c == '[' || c == '{') {
+          depth++;
+        } else if (c == ']' || c == '}') {
+          if (depth > 0) depth--;
+        } else if (c == ':' && depth == 0) {
+          return i;
+        }
+      }
+    }
+    return -1;
+  }
+
+  static int _inlineCommentIndex(String s) {
+    var inSingle = false;
+    var inDouble = false;
+    for (var i = 0; i < s.length; i++) {
+      final c = s[i];
+      if (c == "'" && !inDouble) {
+        inSingle = !inSingle;
+      } else if (c == '"' && !inSingle) {
+        inDouble = !inDouble;
+      } else if (c == '#' && !inSingle && !inDouble) {
+        if (i == 0 || s[i - 1] == ' ' || s[i - 1] == '\t') {
+          return i;
+        }
+      }
+    }
+    return -1;
+  }
+
+  static String _unescapeDouble(String s) {
+    if (!s.contains(r'\')) return s;
+    final buffer = StringBuffer();
+    for (var i = 0; i < s.length; i++) {
+      final c = s[i];
+      if (c == r'\' && i + 1 < s.length) {
+        final n = s[i + 1];
+        switch (n) {
+          case 'n':
+            buffer.write('\n');
+            break;
+          case 't':
+            buffer.write('\t');
+            break;
+          case 'r':
+            buffer.write('\r');
+            break;
+          case '"':
+            buffer.write('"');
+            break;
+          case r'\':
+            buffer.write(r'\');
+            break;
+          case '0':
+            buffer.write('\x00');
+            break;
+          default:
+            buffer.write(n);
+        }
+        i++;
+      } else {
+        buffer.write(c);
+      }
+    }
+    return buffer.toString();
+  }
+}
+
+/// A significant frontmatter line: its indentation and trimmed content.
+class _FmLine {
+  const _FmLine(this.indent, this.content);
+
+  final int indent;
+  final String content;
+
+  /// Whether this line begins a block-sequence entry (`- ...` or a bare `-`).
+  bool get isSeqItem => content == '-' || content.startsWith('- ');
+}
+
+/// A small recursive descent parser for the YAML subset used in frontmatter.
+class _FrontmatterParser {
+  _FrontmatterParser(this.lines);
+
+  final List<_FmLine> lines;
+  int _i = 0;
+
+  Map<String, dynamic> parse() {
+    if (lines.isEmpty) return <String, dynamic>{};
+    // Frontmatter roots are always mappings.
+    return _parseMap(lines.first.indent);
+  }
+
+  Map<String, dynamic> _parseMap(int indent) {
+    final map = <String, dynamic>{};
+    while (_i < lines.length) {
+      final line = lines[_i];
+      if (line.indent < indent) break;
+      if (line.indent > indent) {
+        // Orphan deeper line without a parent key — skip to stay safe.
+        _i++;
+        continue;
+      }
+      if (line.isSeqItem) break; // a sequence is not part of this mapping
+      final kv = GptMarkdownFrontmatter._splitKeyValue(line.content);
+      if (kv == null) {
+        _i++;
+        continue;
+      }
+      final key = GptMarkdownFrontmatter._parseKey(kv[0]);
+      final valueText = kv[1].trim();
+      _i++;
+      if (valueText.isEmpty) {
+        map[key] = _parseChild(indent);
+      } else if (_isBlockScalarHeader(valueText)) {
+        map[key] = _parseBlockScalar(indent, fold: valueText[0] == '>');
+      } else {
+        map[key] = GptMarkdownFrontmatter._parseScalar(valueText);
+      }
+    }
+    return map;
+  }
+
+  List<dynamic> _parseSeq(int indent) {
+    final list = <dynamic>[];
+    while (_i < lines.length) {
+      final line = lines[_i];
+      if (line.indent < indent) break;
+      if (line.indent > indent) {
+        _i++;
+        continue;
+      }
+      if (!line.isSeqItem) break;
+      final rest =
+          line.content == '-' ? '' : line.content.substring(2).trim();
+      if (rest.isEmpty) {
+        // The item's value lives on the following, more-indented lines.
+        _i++;
+        list.add(_parseChild(indent));
+      } else if (GptMarkdownFrontmatter._splitKeyValue(rest) != null) {
+        // Compact mapping inside a sequence: "- key: value". Rewrite the dash
+        // line as a normal mapping entry past the dash, then let _parseMap
+        // absorb it together with any aligned continuation lines.
+        lines[_i] = _FmLine(indent + 2, rest);
+        list.add(_parseMap(indent + 2));
+      } else {
+        _i++;
+        list.add(GptMarkdownFrontmatter._parseScalar(rest));
+      }
+    }
+    return list;
+  }
+
+  /// Parses the block value (mapping or sequence) belonging to a key whose own
+  /// line is at [keyIndent]. A block sequence may share the key's indentation.
+  dynamic _parseChild(int keyIndent) {
+    if (_i >= lines.length) return null;
+    final next = lines[_i];
+    if (next.isSeqItem && next.indent >= keyIndent) {
+      return _parseSeq(next.indent);
+    }
+    if (next.indent > keyIndent) {
+      if (next.isSeqItem) return _parseSeq(next.indent);
+      return _parseMap(next.indent);
+    }
+    return null;
+  }
+
+  bool _isBlockScalarHeader(String value) {
+    if (value.isEmpty) return false;
+    final indicator = value[0];
+    if (indicator != '|' && indicator != '>') return false;
+    final rest = value.substring(1);
+    // Allow chomping/keep indicators like `|-`, `>+`.
+    return rest.isEmpty || rest == '-' || rest == '+';
+  }
+
+  String _parseBlockScalar(int parentIndent, {required bool fold}) {
+    final parts = <String>[];
+    int? base;
+    while (_i < lines.length) {
+      final line = lines[_i];
+      if (line.indent <= parentIndent) break;
+      base ??= line.indent;
+      final dedent = line.indent - base;
+      parts.add((dedent > 0 ? ' ' * dedent : '') + line.content);
+      _i++;
+    }
+    return fold ? parts.join(' ') : parts.join('\n');
+  }
+}

--- a/lib/gpt_markdown.dart
+++ b/lib/gpt_markdown.dart
@@ -17,6 +17,7 @@ import 'custom_widgets/link_button.dart';
 part 'theme.dart';
 part 'markdown_component.dart';
 part 'md_widget.dart';
+part 'frontmatter.dart';
 
 /// This widget create a full markdown widget as a column view.
 class GptMarkdown extends StatelessWidget {
@@ -44,6 +45,7 @@ class GptMarkdown extends StatelessWidget {
     this.components,
     this.inlineComponents,
     this.useDollarSignsForLatex = false,
+    this.frontmatterBuilder,
   });
 
   /// The direction of the text.
@@ -100,6 +102,23 @@ class GptMarkdown extends StatelessWidget {
 
   /// Whether to use dollar signs for LaTeX.
   final bool useDollarSignsForLatex;
+
+  /// Builder for the document's YAML frontmatter.
+  ///
+  /// When the markdown starts with a `---` fenced frontmatter block, it is
+  /// parsed with [GptMarkdownFrontmatter] and removed from the rendered body.
+  /// If [frontmatterBuilder] is provided, its widget is shown above the body;
+  /// otherwise the frontmatter is hidden.
+  ///
+  /// ```dart
+  /// GptMarkdown(
+  ///   agentMarkdown,
+  ///   frontmatterBuilder: (context, frontmatter) {
+  ///     return Text('Agent: ${frontmatter.string('name')}');
+  ///   },
+  /// )
+  /// ```
+  final FrontmatterBuilder? frontmatterBuilder;
 
   /// The table builder.
   final TableBuilder? tableBuilder;
@@ -161,7 +180,12 @@ class GptMarkdown extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    String tex = data.replaceAll('\r\n', '\n').replaceAll('\r', '\n').trim();
+    String tex = data.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+    // Pull the YAML frontmatter (if any) off the top before rendering so it is
+    // not parsed as markdown.
+    final split = GptMarkdownFrontmatter.split(tex);
+    final frontmatter = split.frontmatter;
+    tex = split.body.trim();
     if (useDollarSignsForLatex) {
       tex = tex.replaceAllMapped(
         RegExp(r"(?<!\\)\$\$(.*?)(?<!\\)\$\$", dotAll: true),
@@ -181,7 +205,7 @@ class GptMarkdown extends StatelessWidget {
       }
     }
     // tex = _removeExtraLinesInsideBlockLatex(tex);
-    return ClipRRect(
+    Widget child = ClipRRect(
       child: MdWidget(
         context,
         tex,
@@ -210,5 +234,15 @@ class GptMarkdown extends StatelessWidget {
         ),
       ),
     );
+
+    final frontmatterBuilder = this.frontmatterBuilder;
+    if (frontmatter != null && frontmatterBuilder != null) {
+      child = Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [frontmatterBuilder(context, frontmatter), child],
+      );
+    }
+    return child;
   }
 }

--- a/lib/gpt_markdown.dart
+++ b/lib/gpt_markdown.dart
@@ -107,8 +107,9 @@ class GptMarkdown extends StatelessWidget {
   ///
   /// When the markdown starts with a `---` fenced frontmatter block, it is
   /// parsed with [GptMarkdownFrontmatter] and removed from the rendered body.
-  /// If [frontmatterBuilder] is provided, its widget is shown above the body;
-  /// otherwise the frontmatter is hidden.
+  /// By default the parsed frontmatter is rendered above the body as a
+  /// [GptMarkdownFrontmatterTable]. Provide [frontmatterBuilder] to render it
+  /// your own way instead — return `const SizedBox.shrink()` to hide it.
   ///
   /// ```dart
   /// GptMarkdown(
@@ -235,12 +236,21 @@ class GptMarkdown extends StatelessWidget {
       ),
     );
 
-    final frontmatterBuilder = this.frontmatterBuilder;
-    if (frontmatter != null && frontmatterBuilder != null) {
+    if (frontmatter != null) {
+      // Use the custom builder when provided, otherwise fall back to the
+      // built-in table renderer so frontmatter is visible out of the box.
+      final frontmatterBuilder = this.frontmatterBuilder;
+      final header =
+          frontmatterBuilder != null
+              ? frontmatterBuilder(context, frontmatter)
+              : GptMarkdownFrontmatterTable(
+                frontmatter: frontmatter,
+                style: style,
+              );
       child = Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: [frontmatterBuilder(context, frontmatter), child],
+        children: [header, child],
       );
     }
     return child;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gpt_markdown
 description: "Powerful Flutter Markdown & LaTeX Renderer: Rich Text, Math, Tables, Links, and Text Selection. Ideal for ChatGPT, Gemini, and more."
-version: 1.2.0
+version: 1.2.1
 homepage: https://gptmarkdown.com
 repository: https://github.com/Infinitix-LLC/gpt_markdown
 issue_tracker: https://github.com/Infinitix-LLC/gpt_markdown/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gpt_markdown
 description: "Powerful Flutter Markdown & LaTeX Renderer: Rich Text, Math, Tables, Links, and Text Selection. Ideal for ChatGPT, Gemini, and more."
-version: 1.2.1
+version: 1.2.2
 homepage: https://gptmarkdown.com
 repository: https://github.com/Infinitix-LLC/gpt_markdown
 issue_tracker: https://github.com/Infinitix-LLC/gpt_markdown/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: gpt_markdown
 description: "Powerful Flutter Markdown & LaTeX Renderer: Rich Text, Math, Tables, Links, and Text Selection. Ideal for ChatGPT, Gemini, and more."
-version: 1.1.7
+version: 1.2.0
 homepage: https://gptmarkdown.com
 repository: https://github.com/Infinitix-LLC/gpt_markdown
 issue_tracker: https://github.com/Infinitix-LLC/gpt_markdown/issues

--- a/test/frontmatter/frontmatter_parser_test.dart
+++ b/test/frontmatter/frontmatter_parser_test.dart
@@ -1,0 +1,267 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+
+void main() {
+  group('GptMarkdownFrontmatter.split', () {
+    test('returns null frontmatter when document has none', () {
+      const source = '# Hello\n\nNo frontmatter here.';
+      final result = GptMarkdownFrontmatter.split(source);
+      expect(result.frontmatter, isNull);
+      expect(result.body, source);
+    });
+
+    test('splits frontmatter from the body', () {
+      const source = '---\ntitle: Hello\n---\n# Body';
+      final result = GptMarkdownFrontmatter.split(source);
+      expect(result.frontmatter, isNotNull);
+      expect(result.frontmatter!.string('title'), 'Hello');
+      expect(result.body.trim(), '# Body');
+    });
+
+    test('accepts the "..." closing fence', () {
+      const source = '---\ntitle: Hello\n...\n# Body';
+      final result = GptMarkdownFrontmatter.split(source);
+      expect(result.frontmatter, isNotNull);
+      expect(result.frontmatter!.string('title'), 'Hello');
+      expect(result.body.trim(), '# Body');
+    });
+
+    test('handles CRLF line endings', () {
+      const source = '---\r\ntitle: Hello\r\n---\r\n# Body';
+      final result = GptMarkdownFrontmatter.split(source);
+      expect(result.frontmatter!.string('title'), 'Hello');
+      expect(result.body.trim(), '# Body');
+    });
+
+    test('tolerates leading blank lines before the fence', () {
+      const source = '\n\n---\ntitle: Hello\n---\n# Body';
+      final result = GptMarkdownFrontmatter.split(source);
+      expect(result.frontmatter, isNotNull);
+      expect(result.frontmatter!.string('title'), 'Hello');
+    });
+
+    test('treats an unterminated fence as a normal document', () {
+      const source = '---\ntitle: Hello\n# Body';
+      final result = GptMarkdownFrontmatter.split(source);
+      expect(result.frontmatter, isNull);
+      expect(result.body, source);
+    });
+
+    test('does not treat a mid-document --- as frontmatter', () {
+      const source = '# Title\n\n---\n\nMore text';
+      final result = GptMarkdownFrontmatter.split(source);
+      expect(result.frontmatter, isNull);
+      expect(result.body, source);
+    });
+
+    test('treats an empty/fieldless block as not frontmatter', () {
+      // `---\n---` and `---\n\n---` are adjacent horizontal rules, not an empty
+      // frontmatter block, so they must render as markdown.
+      for (final source in ['---\n---\n# Body', '---\n\n---']) {
+        final result = GptMarkdownFrontmatter.split(source);
+        expect(result.frontmatter, isNull, reason: source);
+        expect(result.body, source);
+      }
+    });
+  });
+
+  group('GptMarkdownFrontmatter.parse scalars', () {
+    test('coerces types', () {
+      final fm = GptMarkdownFrontmatter.parse('''
+---
+title: My Doc
+count: 42
+ratio: 3.14
+published: true
+draft: false
+deleted: null
+empty: ~
+version: 1.2.0
+---
+''');
+      expect(fm, isNotNull);
+      expect(fm!['title'], 'My Doc');
+      expect(fm['count'], 42);
+      expect(fm['ratio'], 3.14);
+      expect(fm['published'], isTrue);
+      expect(fm['draft'], isFalse);
+      expect(fm['deleted'], isNull);
+      expect(fm['empty'], isNull);
+      // Looks like a version, not a number — stays a string.
+      expect(fm['version'], '1.2.0');
+    });
+
+    test('handles quoted strings', () {
+      final fm = GptMarkdownFrontmatter.parse('''
+---
+double: "hello: world"
+single: 'it''s here'
+colon_value: time is 12:30
+escaped: "line1\\nline2"
+---
+''');
+      expect(fm!['double'], 'hello: world');
+      expect(fm['single'], "it's here");
+      expect(fm['colon_value'], 'time is 12:30');
+      expect(fm['escaped'], 'line1\nline2');
+    });
+
+    test('strips inline comments on unquoted scalars', () {
+      final fm = GptMarkdownFrontmatter.parse('''
+---
+name: value # this is a comment
+url: https://example.com#anchor
+---
+''');
+      expect(fm!['name'], 'value');
+      // No space before '#', so it is part of the value.
+      expect(fm['url'], 'https://example.com#anchor');
+    });
+
+    test('ignores full-line comments', () {
+      final fm = GptMarkdownFrontmatter.parse('''
+---
+# leading comment
+name: value
+# trailing comment
+---
+''');
+      expect(fm!.keys, ['name']);
+      expect(fm['name'], 'value');
+    });
+  });
+
+  group('GptMarkdownFrontmatter.parse collections', () {
+    test('parses a block sequence at the key indent', () {
+      final fm = GptMarkdownFrontmatter.parse('''
+---
+tags:
+- flutter
+- markdown
+- yaml
+---
+''');
+      expect(fm!['tags'], ['flutter', 'markdown', 'yaml']);
+      expect(fm.stringList('tags'), ['flutter', 'markdown', 'yaml']);
+    });
+
+    test('parses an indented block sequence', () {
+      final fm = GptMarkdownFrontmatter.parse('''
+---
+tags:
+  - flutter
+  - markdown
+---
+''');
+      expect(fm!['tags'], ['flutter', 'markdown']);
+    });
+
+    test('parses a flow sequence', () {
+      final fm = GptMarkdownFrontmatter.parse('''
+---
+tags: [flutter, markdown, "yaml, too"]
+nums: [1, 2, 3]
+---
+''');
+      expect(fm!['tags'], ['flutter', 'markdown', 'yaml, too']);
+      expect(fm['nums'], [1, 2, 3]);
+    });
+
+    test('parses a nested mapping', () {
+      final fm = GptMarkdownFrontmatter.parse('''
+---
+author:
+  name: Jacob
+  email: jacob@example.com
+  social:
+    github: jacob
+---
+''');
+      final author = fm!['author'] as Map;
+      expect(author['name'], 'Jacob');
+      expect(author['email'], 'jacob@example.com');
+      expect((author['social'] as Map)['github'], 'jacob');
+    });
+
+    test('parses a flow mapping', () {
+      final fm = GptMarkdownFrontmatter.parse('''
+---
+point: {x: 1, y: 2}
+---
+''');
+      final point = fm!['point'] as Map;
+      expect(point['x'], 1);
+      expect(point['y'], 2);
+    });
+
+    test('parses a sequence of compact mappings', () {
+      final fm = GptMarkdownFrontmatter.parse('''
+---
+tools:
+  - name: Read
+    enabled: true
+  - name: Write
+    enabled: false
+---
+''');
+      final tools = fm!['tools'] as List;
+      expect(tools.length, 2);
+      expect((tools[0] as Map)['name'], 'Read');
+      expect((tools[0] as Map)['enabled'], isTrue);
+      expect((tools[1] as Map)['name'], 'Write');
+      expect((tools[1] as Map)['enabled'], isFalse);
+    });
+  });
+
+  group('GptMarkdownFrontmatter.parse block scalars', () {
+    test('literal block scalar preserves line breaks', () {
+      final fm = GptMarkdownFrontmatter.parse('''
+---
+description: |
+  Line one
+  Line two
+---
+''');
+      expect(fm!['description'], 'Line one\nLine two');
+    });
+
+    test('folded block scalar joins lines with spaces', () {
+      final fm = GptMarkdownFrontmatter.parse('''
+---
+description: >
+  Line one
+  Line two
+---
+''');
+      expect(fm!['description'], 'Line one Line two');
+    });
+  });
+
+  group('GptMarkdownFrontmatter helpers', () {
+    test('stringList wraps scalars and tolerates missing keys', () {
+      final fm = GptMarkdownFrontmatter.parse('''
+---
+single: hello
+---
+''');
+      expect(fm!.stringList('single'), ['hello']);
+      expect(fm.stringList('missing'), isEmpty);
+    });
+
+    test('string() coerces and containsKey works', () {
+      final fm = GptMarkdownFrontmatter.parse('''
+---
+count: 7
+---
+''');
+      expect(fm!.string('count'), '7');
+      expect(fm.containsKey('count'), isTrue);
+      expect(fm.containsKey('nope'), isFalse);
+    });
+
+    test('exposes raw text', () {
+      final fm = GptMarkdownFrontmatter.parse('---\na: 1\nb: 2\n---\n');
+      expect(fm!.raw, 'a: 1\nb: 2');
+    });
+  });
+}

--- a/test/frontmatter/frontmatter_parser_test.dart
+++ b/test/frontmatter/frontmatter_parser_test.dart
@@ -264,4 +264,33 @@ count: 7
       expect(fm!.raw, 'a: 1\nb: 2');
     });
   });
+
+  group('GptMarkdownFrontmatter realistic agent.md', () {
+    test('parses values with punctuation, quotes and em dashes', () {
+      const src = '''
+---
+name: backend-scout
+description: Scout read-only do backend .NET (BackOfficeHub). Use para localizar código — endpoints, handlers — e responder "onde está X?", "quem chama Y?". Não edita arquivos; retorna paths.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+Você é um agente scout.
+''';
+      final result = GptMarkdownFrontmatter.split(src);
+      final fm = result.frontmatter;
+      expect(fm, isNotNull);
+      expect(fm!.keys.toList(), ['name', 'description', 'tools', 'model']);
+      expect(fm['name'], 'backend-scout');
+      expect(fm['model'], 'sonnet');
+      // Comma-separated (non-flow) values stay as a single string.
+      expect(fm['tools'], 'Read, Grep, Glob, Bash');
+      expect(
+        fm.string('description'),
+        startsWith('Scout read-only do backend .NET (BackOfficeHub).'),
+      );
+      expect(fm.string('description'), contains('"onde está X?"'));
+      expect(result.body.trim(), 'Você é um agente scout.');
+    });
+  });
 }

--- a/test/frontmatter/frontmatter_widget_test.dart
+++ b/test/frontmatter/frontmatter_widget_test.dart
@@ -41,6 +41,20 @@ void main() {
       expect(find.textContaining('Body paragraph.'), findsOneWidget);
     });
 
+    testWidgets('key cells stretch to fill the row height', (tester) async {
+      await _pump(tester, GptMarkdown(_agentMd));
+      // The colored key cells use fill alignment so their background covers the
+      // whole cell even when the value wraps onto several lines.
+      final keyCells = tester.widgetList<TableCell>(find.byType(TableCell));
+      expect(keyCells, isNotEmpty);
+      expect(
+        keyCells.every(
+          (c) => c.verticalAlignment == TableCellVerticalAlignment.fill,
+        ),
+        isTrue,
+      );
+    });
+
     testWidgets('does not re-render frontmatter in the markdown body', (
       tester,
     ) async {

--- a/test/frontmatter/frontmatter_widget_test.dart
+++ b/test/frontmatter/frontmatter_widget_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+
+import '../utils/test_helpers.dart';
+
+// A document whose body is a single paragraph keeps the serialized output
+// predictable (headings serialize as LATEX in the test serializer).
+const _stripDoc =
+    '---\n'
+    'title: Secret Meta\n'
+    'description: Reviews diffs for bugs.\n'
+    'tags: [alpha, beta]\n'
+    '---\n'
+    'Visible paragraph.';
+
+const _agentMd = '''
+---
+name: code-reviewer
+description: Reviews diffs for bugs.
+tags:
+  - review
+  - quality
+---
+
+# Code Reviewer
+
+Body text here.
+''';
+
+void main() {
+  group('Frontmatter rendering', () {
+    testWidgets('strips frontmatter from the rendered body', (tester) async {
+      await pumpMarkdown(tester, _stripDoc);
+      final output = getSerializedOutput(tester);
+
+      // The body still renders...
+      expect(output, 'TEXT("Visible paragraph.")');
+
+      // ...and none of the frontmatter leaks into the rendered output.
+      expect(output, isNot(contains('Secret Meta')));
+      expect(output, isNot(contains('description')));
+      expect(output, isNot(contains('alpha')));
+      expect(output, isNot(contains('beta')));
+    });
+
+    testWidgets('does not render a stray HR for the fences', (tester) async {
+      await pumpMarkdown(tester, _stripDoc);
+      final output = getSerializedOutput(tester);
+      // If the fences leaked through they would render as horizontal rules.
+      expect(output, isNot(contains('HR')));
+    });
+
+    testWidgets('renders frontmatterBuilder output above the body', (
+      tester,
+    ) async {
+      GptMarkdownFrontmatter? captured;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: GptMarkdown(
+                _agentMd,
+                frontmatterBuilder: (context, frontmatter) {
+                  captured = frontmatter;
+                  return Text('AGENT: ${frontmatter.string('name')}');
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The builder received the parsed frontmatter.
+      expect(captured, isNotNull);
+      expect(captured!.string('name'), 'code-reviewer');
+      expect(captured!.stringList('tags'), ['review', 'quality']);
+
+      // The builder's widget is in the tree.
+      expect(find.text('AGENT: code-reviewer'), findsOneWidget);
+    });
+
+    testWidgets('does not call builder when there is no frontmatter', (
+      tester,
+    ) async {
+      var called = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GptMarkdown(
+              'Plain paragraph.',
+              frontmatterBuilder: (context, frontmatter) {
+                called = true;
+                return const Text('SHOULD NOT APPEAR');
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(called, isFalse);
+      expect(find.text('SHOULD NOT APPEAR'), findsNothing);
+    });
+
+    testWidgets('hides frontmatter when no builder is provided', (
+      tester,
+    ) async {
+      await pumpMarkdown(tester, _stripDoc);
+      final output = getSerializedOutput(tester);
+      // Still just the body — the frontmatter is silently dropped.
+      expect(output, 'TEXT("Visible paragraph.")');
+    });
+
+    testWidgets('document without frontmatter renders unchanged', (
+      tester,
+    ) async {
+      await pumpMarkdown(tester, 'Some **bold** text.');
+      final output = getSerializedOutput(tester);
+      expect(output, contains('TEXT("bold")[bold]'));
+    });
+  });
+}

--- a/test/frontmatter/frontmatter_widget_test.dart
+++ b/test/frontmatter/frontmatter_widget_test.dart
@@ -1,124 +1,112 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:gpt_markdown/custom_widgets/custom_divider.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
-
-import '../utils/test_helpers.dart';
-
-// A document whose body is a single paragraph keeps the serialized output
-// predictable (headings serialize as LATEX in the test serializer).
-const _stripDoc =
-    '---\n'
-    'title: Secret Meta\n'
-    'description: Reviews diffs for bugs.\n'
-    'tags: [alpha, beta]\n'
-    '---\n'
-    'Visible paragraph.';
 
 const _agentMd = '''
 ---
 name: code-reviewer
 description: Reviews diffs for bugs.
-tags:
-  - review
-  - quality
+tools: Read, Grep, Glob, Bash
+model: sonnet
 ---
 
-# Code Reviewer
-
-Body text here.
+Body paragraph.
 ''';
+
+Future<void> _pump(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    MaterialApp(home: Scaffold(body: SingleChildScrollView(child: child))),
+  );
+  await tester.pumpAndSettle();
+}
 
 void main() {
   group('Frontmatter rendering', () {
-    testWidgets('strips frontmatter from the rendered body', (tester) async {
-      await pumpMarkdown(tester, _stripDoc);
-      final output = getSerializedOutput(tester);
+    testWidgets('renders frontmatter as a table by default', (tester) async {
+      await _pump(tester, GptMarkdown(_agentMd));
 
-      // The body still renders...
-      expect(output, 'TEXT("Visible paragraph.")');
+      // The default renderer is a table of key/value rows.
+      expect(find.byType(GptMarkdownFrontmatterTable), findsOneWidget);
+      expect(find.byType(Table), findsOneWidget);
 
-      // ...and none of the frontmatter leaks into the rendered output.
-      expect(output, isNot(contains('Secret Meta')));
-      expect(output, isNot(contains('description')));
-      expect(output, isNot(contains('alpha')));
-      expect(output, isNot(contains('beta')));
+      // Keys and values are visible in the table.
+      expect(find.text('name'), findsOneWidget);
+      expect(find.text('code-reviewer'), findsOneWidget);
+      expect(find.text('tools'), findsOneWidget);
+      expect(find.text('Read, Grep, Glob, Bash'), findsOneWidget);
+      expect(find.text('model'), findsOneWidget);
+
+      // The body still renders.
+      expect(find.textContaining('Body paragraph.'), findsOneWidget);
     });
 
-    testWidgets('does not render a stray HR for the fences', (tester) async {
-      await pumpMarkdown(tester, _stripDoc);
-      final output = getSerializedOutput(tester);
-      // If the fences leaked through they would render as horizontal rules.
-      expect(output, isNot(contains('HR')));
+    testWidgets('does not re-render frontmatter in the markdown body', (
+      tester,
+    ) async {
+      await _pump(tester, GptMarkdown(_agentMd));
+      // If the fences leaked into the body, the raw YAML line would render.
+      expect(find.textContaining('name: code-reviewer'), findsNothing);
+      // The fences must not become horizontal rules.
+      expect(find.byType(CustomDivider), findsNothing);
     });
 
-    testWidgets('renders frontmatterBuilder output above the body', (
+    testWidgets('frontmatterBuilder overrides the default table', (
       tester,
     ) async {
       GptMarkdownFrontmatter? captured;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: SingleChildScrollView(
-              child: GptMarkdown(
-                _agentMd,
-                frontmatterBuilder: (context, frontmatter) {
-                  captured = frontmatter;
-                  return Text('AGENT: ${frontmatter.string('name')}');
-                },
-              ),
-            ),
-          ),
+      await _pump(
+        tester,
+        GptMarkdown(
+          _agentMd,
+          frontmatterBuilder: (context, frontmatter) {
+            captured = frontmatter;
+            return Text('AGENT: ${frontmatter.string('name')}');
+          },
         ),
       );
-      await tester.pumpAndSettle();
 
       // The builder received the parsed frontmatter.
       expect(captured, isNotNull);
       expect(captured!.string('name'), 'code-reviewer');
-      expect(captured!.stringList('tags'), ['review', 'quality']);
 
-      // The builder's widget is in the tree.
+      // The custom widget replaces the default table.
       expect(find.text('AGENT: code-reviewer'), findsOneWidget);
+      expect(find.byType(GptMarkdownFrontmatterTable), findsNothing);
     });
 
-    testWidgets('does not call builder when there is no frontmatter', (
+    testWidgets('builder can hide the frontmatter', (tester) async {
+      await _pump(
+        tester,
+        GptMarkdown(
+          _agentMd,
+          frontmatterBuilder: (context, frontmatter) =>
+              const SizedBox.shrink(),
+        ),
+      );
+      expect(find.byType(GptMarkdownFrontmatterTable), findsNothing);
+      expect(find.text('code-reviewer'), findsNothing);
+      expect(find.textContaining('Body paragraph.'), findsOneWidget);
+    });
+
+    testWidgets('no frontmatter → no table, builder not called', (
       tester,
     ) async {
       var called = false;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: GptMarkdown(
-              'Plain paragraph.',
-              frontmatterBuilder: (context, frontmatter) {
-                called = true;
-                return const Text('SHOULD NOT APPEAR');
-              },
-            ),
-          ),
+      await _pump(
+        tester,
+        GptMarkdown(
+          'Plain paragraph.',
+          frontmatterBuilder: (context, frontmatter) {
+            called = true;
+            return const Text('SHOULD NOT APPEAR');
+          },
         ),
       );
-      await tester.pumpAndSettle();
-
       expect(called, isFalse);
+      expect(find.byType(GptMarkdownFrontmatterTable), findsNothing);
       expect(find.text('SHOULD NOT APPEAR'), findsNothing);
-    });
-
-    testWidgets('hides frontmatter when no builder is provided', (
-      tester,
-    ) async {
-      await pumpMarkdown(tester, _stripDoc);
-      final output = getSerializedOutput(tester);
-      // Still just the body — the frontmatter is silently dropped.
-      expect(output, 'TEXT("Visible paragraph.")');
-    });
-
-    testWidgets('document without frontmatter renders unchanged', (
-      tester,
-    ) async {
-      await pumpMarkdown(tester, 'Some **bold** text.');
-      final output = getSerializedOutput(tester);
-      expect(output, contains('TEXT("bold")[bold]'));
+      expect(find.textContaining('Plain paragraph.'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Adds YAML frontmatter support to `GptMarkdown`.

Frontmatter is the `---` fenced metadata block at the top of a document — the header shown for AI **Agents** and **Skills** (`agent.md` / `SKILL.md` files). Today gpt_markdown renders it as a stray horizontal rule plus raw text; this PR parses it out of the body.

## What's included
- **Parsing** — new `GptMarkdownFrontmatter`, a dependency-free parser for the common YAML subset: scalars (with `int`/`double`/`bool`/`null` coercion), quoted strings, nested maps, block & flow sequences, flow maps, block scalars (`|`/`>`) and `#` comments. `GptMarkdownFrontmatter.parse` / `.split` let you read metadata without rendering.
- **Default rendering** — frontmatter is shown as a `key | value` table above the body via the new `GptMarkdownFrontmatterTable` widget, like editors display agent/skill metadata.
- **New builder** — `frontmatterBuilder` parameter (+ `FrontmatterBuilder` typedef) to render it your own way; return `const SizedBox.shrink()` to hide it.
- **Backwards compatible** — a `---` block that yields no fields (e.g. two adjacent horizontal rules) still renders as markdown.

## Also
- Tests for the parser and widget integration.
- README + CHANGELOG updated; version bumped to `1.2.2`.
- Example app + playground updated, plus a sample `example/agent.md`.