### PR TITLE
Fix double text scaling in WidgetSpan-rendered elements (lists, headings, links)

### DIFF
--- a/lib/markdown_component.dart
+++ b/lib/markdown_component.dart
@@ -1,5 +1,20 @@
 part of 'gpt_markdown.dart';
 
+/// Prepares [child] to be embedded in a [WidgetSpan].
+///
+/// Flutter already magnifies a [WidgetSpan]'s child geometrically by the host
+/// paragraph's text scale factor (see [WidgetSpan.extractFromInlineSpan] and
+/// its `_RenderScaledInlineWidget`). Any text rendered inside that child must
+/// therefore not apply the text scaler a second time, or it ends up scaled
+/// quadratically — visibly larger than the surrounding prose when the user
+/// increases the system font size, and smaller when they decrease it.
+Widget _unscaledSpanChild(BuildContext context, Widget child) {
+  return MediaQuery(
+    data: MediaQuery.of(context).copyWith(textScaler: TextScaler.noScaling),
+    child: child,
+  );
+}
+
 /// Markdown components
 abstract class MarkdownComponent {
   static List<MarkdownComponent> get globalComponents => [
@@ -127,7 +142,15 @@ abstract class BlockMd extends MarkdownComponent {
     var matches = RegExp(r'^(?<spaces>\ \ +).*').firstMatch(text);
     var spaces = matches?.namedGroup('spaces');
     var length = spaces?.length ?? 0;
-    var child = build(context, text, config);
+    // Block content is returned as a `WidgetSpan` below, so it must not apply
+    // the text scaler a second time (see [_unscaledSpanChild]). Neutralize the
+    // explicit scaler that `GptMarkdownConfig.getRich` hands to `Text.rich`
+    // here, and the ambient one via `_unscaledSpanChild` below.
+    var child = build(
+      context,
+      text,
+      config.copyWith(textScaler: TextScaler.noScaling),
+    );
     length = min(length, 4);
     if (length > 0) {
       child = UnorderedListView(
@@ -141,7 +164,7 @@ abstract class BlockMd extends MarkdownComponent {
       children: [Flexible(child: child)],
     );
     return WidgetSpan(
-      child: child,
+      child: _unscaledSpanChild(context, child),
       alignment: PlaceholderAlignment.baseline,
       baseline: TextBaseline.alphabetic,
     );
@@ -867,7 +890,12 @@ class ATagMd extends InlineMd {
         decorationColor: theme.linkColor,
         decoration: TextDecoration.underline,
       );
-      final linkConfig = config.copyWith(style: linkStyle);
+      // Link content is embedded in a `WidgetSpan` below, so it must not apply
+      // the text scaler a second time (see [_unscaledSpanChild]).
+      final linkConfig = config.copyWith(
+        style: linkStyle,
+        textScaler: TextScaler.noScaling,
+      );
       final linkTextSpan = TextSpan(
         children: MarkdownComponent.generate(
           context,
@@ -880,13 +908,16 @@ class ATagMd extends InlineMd {
       child = WidgetSpan(
         baseline: TextBaseline.alphabetic,
         alignment: PlaceholderAlignment.baseline,
-        child: GestureDetector(
-          onTap: () => config.onLinkTap?.call(url, linkText),
-          child: builder(
-            context,
-            linkTextSpan,
-            url,
-            config.style ?? const TextStyle(),
+        child: _unscaledSpanChild(
+          context,
+          GestureDetector(
+            onTap: () => config.onLinkTap?.call(url, linkText),
+            child: builder(
+              context,
+              linkTextSpan,
+              url,
+              config.style ?? const TextStyle(),
+            ),
           ),
         ),
       );
@@ -897,30 +928,38 @@ class ATagMd extends InlineMd {
     child ??= WidgetSpan(
       alignment: PlaceholderAlignment.baseline,
       baseline: TextBaseline.alphabetic,
-      child: LinkButton(
-        hoverColor: theme.linkHoverColor,
-        color: theme.linkColor,
-        onPressed: () {
-          config.onLinkTap?.call(url, linkText);
-        },
-        text: linkText,
-        config: config,
-        spanBuilder: (color) {
-          final spanStyle = (config.style ?? const TextStyle()).copyWith(
-            color: color,
-            decorationColor: color,
-            decoration: TextDecoration.underline,
-          );
-          return TextSpan(
-            children: MarkdownComponent.generate(
-              context,
-              linkText,
-              config.copyWith(style: spanStyle),
-              false,
-            ),
-            style: spanStyle,
-          );
-        },
+      child: _unscaledSpanChild(
+        context,
+        LinkButton(
+          hoverColor: theme.linkHoverColor,
+          color: theme.linkColor,
+          onPressed: () {
+            config.onLinkTap?.call(url, linkText);
+          },
+          text: linkText,
+          // `LinkButton` renders the link text through `config.getRich`, so it
+          // needs the neutralized scaler too (see [_unscaledSpanChild]).
+          config: config.copyWith(textScaler: TextScaler.noScaling),
+          spanBuilder: (color) {
+            final spanStyle = (config.style ?? const TextStyle()).copyWith(
+              color: color,
+              decorationColor: color,
+              decoration: TextDecoration.underline,
+            );
+            return TextSpan(
+              children: MarkdownComponent.generate(
+                context,
+                linkText,
+                config.copyWith(
+                  style: spanStyle,
+                  textScaler: TextScaler.noScaling,
+                ),
+                false,
+              ),
+              style: spanStyle,
+            );
+          },
+        ),
       ),
     );
     var textSpan = TextSpan(children: [child, ...endingSpans]);

--- a/test/regression/issue_61_text_scale_test.dart
+++ b/test/regression/issue_61_text_scale_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+
+/// Regression tests for
+/// https://github.com/Infinitix-LLC/gpt_markdown/issues/61.
+///
+/// Elements that are rendered as a [WidgetSpan] — every `BlockMd` (lists,
+/// headings, ...) and links — used to apply the text scaler twice, so they grew
+/// quadratically: visibly larger than the surrounding prose once the reader
+/// raised the system font size, and smaller once they lowered it.
+///
+/// The double scaling is invisible at a scale of exactly 1.0, which is why
+/// these tests assert across several scales.
+void main() {
+  /// The size the glyphs are actually painted at, for every run of text.
+  ///
+  /// This is the leaf span's font size scaled by the paragraph's own
+  /// [TextScaler] *and* by the transform inherited from its ancestors. The
+  /// second factor matters: Flutter magnifies a [WidgetSpan]'s child
+  /// geometrically by the host paragraph's scale factor, so reading
+  /// `textScaler` alone reports these elements as correct when they are
+  /// visibly double-scaled.
+  Map<String, double> paintedSizes(WidgetTester tester) {
+    final sizes = <String, double>{};
+    for (final paragraph in tester.renderObjectList<RenderParagraph>(
+      find.byType(RichText),
+    )) {
+      final geometric = paragraph.getTransformTo(null).getMaxScaleOnAxis();
+      paragraph.text.visitChildren((span) {
+        final text = span is TextSpan ? span.text : null;
+        if (text == null || text.trim().isEmpty) return true;
+        final fontSize = span.style?.fontSize ?? paragraph.text.style?.fontSize;
+        if (fontSize != null) {
+          sizes[text] = paragraph.textScaler.scale(fontSize) * geometric;
+        }
+        return true;
+      });
+    }
+    return sizes;
+  }
+
+  Future<Map<String, double>> pumpAtScale(
+    WidgetTester tester,
+    double scale,
+  ) async {
+    await tester.pumpWidget(
+      MediaQuery(
+        data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+        child: const MaterialApp(
+          home: Scaffold(
+            body: SingleChildScrollView(
+              child: GptMarkdown(
+                'plainprose\n\n'
+                '- bulletitem\n\n'
+                '1. numbereditem\n\n'
+                '# headingtext\n\n'
+                'a [linktext](https://example.com) inline',
+                style: TextStyle(fontSize: 17),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return paintedSizes(tester);
+  }
+
+  const scales = <double>[0.5, 1.0, 1.5, 2.0];
+
+  /// Elements that must be painted at exactly the prose size.
+  const sameAsProse = <String>['bulletitem', 'numbereditem', 'linktext'];
+
+  for (final scale in scales) {
+    testWidgets('issue #61: elements match prose at text scale $scale', (
+      tester,
+    ) async {
+      final sizes = await pumpAtScale(tester, scale);
+
+      final prose = sizes['plainprose'];
+      expect(prose, isNotNull, reason: 'prose should render');
+      for (final element in sameAsProse) {
+        expect(
+          sizes[element],
+          closeTo(prose!, 0.01),
+          reason: '"$element" should be painted at the same size as prose',
+        );
+      }
+    });
+  }
+
+  testWidgets('issue #61: a heading keeps its ratio to prose across scales', (
+    tester,
+  ) async {
+    // A heading is legitimately larger than prose, so the invariant is that the
+    // ratio between them holds — the heading must not scale on top of the
+    // scaling already applied to the paragraph.
+    final baseline = await pumpAtScale(tester, 1);
+    final baseRatio = baseline['headingtext']! / baseline['plainprose']!;
+    expect(baseRatio, greaterThan(1), reason: 'a heading is larger than prose');
+
+    for (final scale in scales) {
+      final sizes = await pumpAtScale(tester, scale);
+      final ratio = sizes['headingtext']! / sizes['plainprose']!;
+      expect(
+        ratio,
+        closeTo(baseRatio, 0.01),
+        reason: 'heading:prose ratio should stay $baseRatio at scale $scale',
+      );
+    }
+  });
+
+  testWidgets('issue #61: text still responds to the scaler', (tester) async {
+    // Guards against "uniform" being achieved by pinning everything to a fixed
+    // size, which would silently break accessibility instead.
+    final small = await pumpAtScale(tester, 0.5);
+    final large = await pumpAtScale(tester, 2);
+
+    for (final key in ['plainprose', 'headingtext', ...sameAsProse]) {
+      expect(
+        large[key],
+        greaterThan(small[key]!),
+        reason: '"$key" should grow when the text scaler grows',
+      );
+    }
+  });
+}

--- a/test/utils/serializer.dart
+++ b/test/utils/serializer.dart
@@ -132,6 +132,13 @@ class MarkdownSerializer {
       return;
     }
 
+    // WidgetSpan content is wrapped in a MediaQuery that neutralizes the text
+    // scaler, since Flutter already scales a WidgetSpan's child geometrically.
+    if (widget is MediaQuery) {
+      _visitWidget(widget.child);
+      return;
+    }
+
     if (widget is Padding && widget.child != null) {
       _visitWidget(widget.child!);
       return;


### PR DESCRIPTION
Fixes #61.

## The problem

Elements rendered as a `WidgetSpan` — every `BlockMd` (lists, headings, blockquotes, tables, code blocks, checkboxes) and links via `ATagMd` — apply the text scaler **twice**, so they scale quadratically.

Flutter magnifies a `WidgetSpan`'s child geometrically by the host paragraph's scale factor: `WidgetSpan.extractFromInlineSpan` builds every child inside a `_RenderScaledInlineWidget` with `textScaleFactor = textScaler.scale(fontSize) / fontSize`, which lays the child out at `width / scale` and paints it at `scale`. That is Flutter working as intended, so inline widgets grow with the surrounding text.

The embedded content then resolves the text scaler *again* — through the explicit scaler `GptMarkdownConfig.getRich` passes to `Text.rich`/`BidiText`, and through the ambient scaler any nested `Text` reads from `MediaQuery`. Net effect: `scale²`.

That is exactly what #61 reports: lists, headings and links render visibly larger than the surrounding prose when the reader raises the system font size, and smaller when they lower it.

Measured on `main` before this change, with `style: TextStyle(fontSize: 17)`, comparing painted glyph sizes:

| element | 0.5× | 1.0× | 1.5× | 2.0× |
|---|---|---|---|---|
| prose (reference) | 8.50 | 17.00 | 25.50 | 34.00 |
| bullet / numbered item | **4.25** | 17.00 | **38.25** | **68.00** |
| link | **4.25** | 17.00 | **38.25** | **68.00** |
| heading (ratio to prose) | **0.94** | 1.88 | **2.82** | **3.76** |

Two things worth calling out:

- At a scale of exactly **1.0** the two factors coincide and everything lines up, which is why this does not show up in default-settings testing.
- Inline code is unaffected, because `HighlightedText` returns a plain `TextSpan` unless a custom `highlightBuilder` is supplied.

This also explains the workarounds in the issue thread. `textScaler: TextScaler.linear(1)` works because it drops the paragraph scaler to 1.0, making the geometric factor 1.0 too — but it disables Dynamic Type entirely, which is what the reporters objected to. And pre-scaling `fontSize` *without* also neutralizing the scaler makes it worse, as @mjurfest observed, because the inflated font size then gets scaled twice.

## The fix

Neutralize the text scaler for `WidgetSpan` content in both places it is applied, via a small shared `_unscaledSpanChild` helper:

- `BlockMd.span` — covers every block component in one place.
- `ATagMd.span` — both the default `LinkButton` path and the custom `linkBuilder` path. `LinkButton` renders link text through `config.getRich`, so it needs the neutralized config too.

The geometric factor Flutter applies is unchanged, so text still scales with the reader's setting — it is just no longer scaled a second time.

## Testing

- New `test/regression/issue_61_text_scale_test.dart` asserts that list items and links are painted at the same size as the surrounding prose, and that a heading holds its ratio to prose, across scales 0.5/1.0/1.5/2.0. It also asserts sizes still *grow* with the scaler, so the invariant cannot be satisfied by pinning everything to a fixed size. These 4 assertions fail on `main` (scale 1.0 passes, as expected) and pass with the fix.
- Full suite: **162 passed, 6 skipped, 0 failed** (156 existing + 6 new). `flutter analyze lib test` is clean.
- `test/utils/serializer.dart` needed one hunk: it unwraps a fixed allow-list of wrapper widgets, so the new `MediaQuery` has to be added or every block/link assertion serializes to nothing. I used a plain `MediaQuery` rather than `MediaQuery.withNoTextScaling` deliberately — the latter inserts a `Builder`, whose child a static widget walker cannot traverse, which would have broken 68 existing tests.
- I did not reformat `lib/custom_widgets/bidi_rich_text.dart` or `test/regression/rtl_inline_widget_order_test.dart`, which `dart format` currently reports as dirty on `main`, to keep this diff focused.

## Known limitation

The compensation is exact for linear scalers. For a non-linear `TextScaler` it is exact only when the embedded content's font size matches the font size Flutter used to compute the placeholder factor (the nearest ancestor span's `fontSize`), so e.g. a heading nested inside a list item could drift slightly. Fully removing that class of problem would mean not rendering block elements as `WidgetSpan`s at all — laying them out as real widgets in a `Column` — which is a much larger architectural change and out of scope here. Happy to explore it separately if you would like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
